### PR TITLE
Reverted curie support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test:
 lint:
 	node_modules/.bin/eslint lib/
 
-dist/ketting.min.js: lib/*.js
+dist/ketting.min.js: lib/*.js lib/*/*.js
 	mkdir -p dist
 	node_modules/.bin/webpack \
 		--optimize-minimize \

--- a/lib/representor/hal.js
+++ b/lib/representor/hal.js
@@ -26,8 +26,6 @@ var Hal = function(uri, contentType, body) {
     this.body = body;
   }
 
-  this.curieMap = {};
-
   if (typeof this.body._links !== 'undefined') {
     parseHalLinks(this);
   }
@@ -50,28 +48,7 @@ Hal.prototype = Object.create(Representation);
  */
 var parseHalLinks = function(representation) {
 
-  /**
-   * Parsing curies first.
-   */
-  if (representation.body._links.curies) {
-    parseHalLink(representation, 'curies', representation.body._links.curies);
-    for(var idx in representation.links) {
-      var curieLink = representation.links[idx];
-      if (curieLink.rel !== 'curies') {
-        // Ignoring anything that's not a curie link, just in case something
-        // else set it.
-        continue;
-      }
-
-      representation.curieMap[curieLink.name] = curieLink;
-    }
-  }
-
   for(var relType in representation.body._links) {
-
-    if (relType === 'curies') {
-      continue;
-    }
 
     var links = representation.body._links[relType];
     if (!Array.isArray(links)) {
@@ -92,14 +69,6 @@ var parseHalLinks = function(representation) {
  * @returns {void}
  */
 var parseHalLink = function(representation, rel, links) {
-
-  if (representation.curieMap && rel.indexOf(':')!==-1) {
-    var parts = rel.split(':',2);
-    if (representation.curieMap[parts[0]]) {
-      rel = representation.curieMap[parts[0]].expand({rel: parts[1]});
-    }
-  }
-
 
   for(var ii in links) {
     representation.links.push(
@@ -126,14 +95,6 @@ var parseHalLink = function(representation, rel, links) {
 var parseHalEmbedded = function(representation) {
 
   for(var relType in representation.body._embedded) {
-
-    // Mapping curies
-    if (representation.curieMap && relType.indexOf(':')!==-1) {
-      var parts = relType.split(':',2)[0];
-      if (representation.curieMap[parts[0]]) {
-        relType = representation.curieMap[parts[0]].expand({rel: parts[1]});
-      }
-    }
 
     var embedded = representation.body._embedded[relType];
     if (!Array.isArray(embedded)) {

--- a/readme.md
+++ b/readme.md
@@ -126,43 +126,6 @@ Further reading:
 * [Further reading](https://evertpot.com/rest-embedding-hal-http2/).
 * [Hypertext Cache Pattern in HAL spec](https://tools.ietf.org/html/draft-kelly-json-hal-08#section-8.3).
 
-### HAL and Curies
-
-HAL has a CURIES feature. If your api uses them, the Ketting library will
-automatically expand them.
-
-For example, from a Ketting perspective, the following HAL document:
-
-```js
-{
-  "_links" : {
-    "foo:website" : {
-      "href": "https://github.com/evert/ketting/",
-    },
-    "curies" : {
-      "href": "http://ns.example.org/{rel}",
-      "templated": true,
-      "name": "foo",
-    }
-  }
-}
-```
-
-Is parsed like this:
-
-```js
-{
-  "_links" : {
-    "http://ns.example.org/website" : {
-      "href": "https://github.com/evert/ketting/",
-    }
-  }
-}
-```
-
-Only the full relation type (`http://ns.example.org/website`) can be used in
-functions such as `follow` and `followAll`.
-
 
 Node and Browser
 ----------------

--- a/test/integration/follow-hal.js
+++ b/test/integration/follow-hal.js
@@ -30,16 +30,6 @@ describe('Following a link', async () => {
 
   });
 
-  it('should automatically expand curies', async() => {
-
-    const resource = await ketting.follow('http://example.org/curie/foo');
-    expect(resource).to.be.an.instanceof(Resource);
-    expect(resource.uri).to.equal('http://localhost:3000/curietarget');
-
-
-  });
-
-
   it('should work with embedded resources', async() => {
 
     const items = await ketting.follow('collection').followAll('item');


### PR DESCRIPTION
According to the HAL mailing list, this is actually not how curies are
intended to behave. Curies don't act as XML namespaces, they just
provide a sort of shortcut to related documentation.