### PR TITLE
initializing newInit as an object

### DIFF
--- a/lib/ketting.js
+++ b/lib/ketting.js
@@ -129,7 +129,7 @@ Ketting.prototype = {
    */
   fetch : function(input, init) {
 
-    var newInit;
+    var newInit = {};
 
     if (init) {
       Object.assign(newInit, this.fetchInit, init);


### PR DESCRIPTION
@enrique-ramirez I tried this in another browser, and got an error related to not initializing an object correctly. I fixed that here

Mind giving this one a shot? Still not 100% sure if this does the trick to you. First time using Object.assign.