### PR TITLE
Enable .Fetch to upload multipart files

### DIFF
--- a/lib/ketting.js
+++ b/lib/ketting.js
@@ -164,7 +164,12 @@ Ketting.prototype = {
       }
 
     }
-
+    
+    //if the header Content-Type is set to multipart - ensure it is cleared so fetch can set correct headers automatically.
+    if (request.headers.get("Content-Type") === "multipart/form-data") {
+      request.headers.delete("Content-Type");
+    }
+    
     return fetch(request);
 
   },


### PR DESCRIPTION
Due to the current setup of always setting content-type header, it is not possible to upload multi-part files
This adds a check to see if fetch is set to use multipart/form-data and clears the contenttype header so it correctly gets set by the fetch api instead. 