### PR TITLE
Add oauth2 owner flow support

### DIFF
--- a/lib/ketting.js
+++ b/lib/ketting.js
@@ -1,9 +1,11 @@
+var ClientOAuth2 = require('client-oauth2');
 var Resource = require('./resource');
 var representor = require('./representor');
 
 var base64 = require('./utils/base64');
-var url = require('./utils/url');
+var oauth = require('./utils/oauth');
 var fetch = require('./utils/fetch');
+var url = require('./utils/url');
 
 /**
  * The main Ketting client object.
@@ -37,6 +39,10 @@ var Ketting = function(bookMark, options) {
 
   if (options.auth) {
     this.auth = options.auth;
+
+    if (options.auth.type == 'oauth2') {
+      this.auth.oauthClient = new ClientOAuth2(options.auth.client);
+    }
   }
 
   if (options.fetchInit) {
@@ -160,7 +166,16 @@ Ketting.prototype = {
       case 'bearer' :
         request.headers.set('Authorization', 'Bearer ' + this.auth.token);
         break;
-
+      case 'oauth2' :
+        if (this.auth.accessToken) {
+          request.headers.set('Authorization', 'Bearer ' + this.auth.accessToken);
+        } else {
+          return oauth.fetchToken(this, request)
+            .then(function (ketting) {
+              return ketting.fetch(input, init);
+            });
+        }
+        break;
       }
 
     }

--- a/lib/ketting.js
+++ b/lib/ketting.js
@@ -1,4 +1,3 @@
-var ClientOAuth2 = require('client-oauth2');
 var Resource = require('./resource');
 var representor = require('./representor');
 
@@ -41,7 +40,7 @@ var Ketting = function(bookMark, options) {
     this.auth = options.auth;
 
     if (options.auth.type == 'oauth2') {
-      this.auth.oauthClient = new ClientOAuth2(options.auth.client);
+      this.auth.oauth = oauth.setupOAuthObject(this, options.auth);
     }
   }
 
@@ -167,11 +166,13 @@ Ketting.prototype = {
         request.headers.set('Authorization', 'Bearer ' + this.auth.token);
         break;
       case 'oauth2' :
-        if (this.auth.accessToken) {
-          request.headers.set('Authorization', 'Bearer ' + this.auth.accessToken);
+        if (this.auth.oauth.token) {
+          request.headers.set('Authorization', 'Bearer ' + this.auth.oauth.token.accessToken);
         } else {
-          return oauth.fetchToken(this, request)
-            .then(function (ketting) {
+          var ketting = this;
+          return this.auth.oauth.getToken(this.auth)
+            .then(function () {
+              // Just call this function again
               return ketting.fetch(input, init);
             });
         }

--- a/lib/ketting.js
+++ b/lib/ketting.js
@@ -40,7 +40,7 @@ var Ketting = function(bookMark, options) {
     this.auth = options.auth;
 
     if (options.auth.type == 'oauth2') {
-      this.auth.oauth = oauth.setupOAuthObject(this, options.auth);
+      this.auth.oauth = oauth.setupOAuthObject(options.auth);
     }
   }
 
@@ -166,17 +166,7 @@ Ketting.prototype = {
         request.headers.set('Authorization', 'Bearer ' + this.auth.token);
         break;
       case 'oauth2' :
-        if (this.auth.oauth.token) {
-          request.headers.set('Authorization', 'Bearer ' + this.auth.oauth.token.accessToken);
-        } else {
-          var ketting = this;
-          return this.auth.oauth.getToken(this.auth)
-            .then(function () {
-              // Just call this function again
-              return ketting.fetch(input, init);
-            });
-        }
-        break;
+        return oauth.fetch(this, request, init);
       }
 
     }

--- a/lib/utils/oauth.js
+++ b/lib/utils/oauth.js
@@ -1,0 +1,33 @@
+module.exports = {
+  /**
+   * Fetches an oauth2 token and sets it on the given ketting class
+   *
+   * @async
+   * @param {object} ketting - Ketting object.
+   * @return {object}
+   */
+  fetchToken: function(ketting) {
+    if (ketting.auth.owner) {
+      return this.ownerFlow(ketting);
+    }
+  },
+
+  /**
+   * Fetches an oauth2 token using the owner flow
+   *
+   * @async
+   * @param {object} ketting - Ketting object.
+   * @return {object}
+   */
+  ownerFlow: function(ketting) {
+    return ketting.auth.oauthClient.owner.getToken(
+      ketting.auth.owner.userName,
+      ketting.auth.owner.password
+    )
+      .then(function (client) {
+        ketting.auth['accessToken'] = client.accessToken;
+        ketting.auth['refreshToken'] = client.refreshToken;
+        return ketting;
+      });
+  }
+};

--- a/lib/utils/oauth.js
+++ b/lib/utils/oauth.js
@@ -10,6 +10,8 @@ module.exports = {
     if (ketting.auth.owner) {
       return this.ownerFlow(ketting);
     }
+
+    throw new Error('Unsupported oauth2 flow');
   },
 
   /**
@@ -25,8 +27,8 @@ module.exports = {
       ketting.auth.owner.password
     )
       .then(function (client) {
-        ketting.auth['accessToken'] = client.accessToken;
-        ketting.auth['refreshToken'] = client.refreshToken;
+        ketting.auth.accessToken = client.accessToken;
+        ketting.auth.refreshToken = client.refreshToken;
         return ketting;
       });
   }

--- a/lib/utils/oauth.js
+++ b/lib/utils/oauth.js
@@ -87,6 +87,14 @@ module.exports = {
     throw new Error('Unsupported oauth2 flow');
   },
 
+
+  /**
+   * Refreshes the access token and updates the existing token with the new one
+   *
+   * @async
+   * @param {object} auth - Auth object.
+   * @return {object}
+   */
   refreshToken : function(auth) {
     return auth.oauth.token.refresh()
       .then(function(updatedToken) {

--- a/lib/utils/oauth.js
+++ b/lib/utils/oauth.js
@@ -1,35 +1,66 @@
+var ClientOAuth2 = require('client-oauth2');
+
+/**
+ * Fetches an oauth2 token using the owner flow
+ *
+ * @async
+ * @param {object} auth - auth object.
+ * @return {object}
+ */
+function ownerFlow(auth) {
+  return auth.oauth.client.owner.getToken(
+    auth.owner.userName,
+    auth.owner.password
+  )
+    .then(function (token) {
+      auth.oauth.token = token;
+      return;
+    });
+}
+
 module.exports = {
   /**
-   * Fetches an oauth2 token and sets it on the given ketting class
+   * Fetches an oauth2 token and sets it on the given auth object
    *
    * @async
-   * @param {object} ketting - Ketting object.
+   * @param {object} auth - Auth object.
    * @return {object}
    */
-  fetchToken: function(ketting) {
-    if (ketting.auth.owner) {
-      return this.ownerFlow(ketting);
+  getToken: function(auth) {
+    if (auth.oauth.flow === 'owner') {
+      return ownerFlow(auth);
     }
 
     throw new Error('Unsupported oauth2 flow');
   },
 
+  refreshToken: function(ketting) {
+    return ketting.auth.oauth.token.refresh()
+      .then(function(updatedToken) {
+        ketting.auth.oauth.token = updatedToken;
+        return;
+      });
+  },
+
   /**
-   * Fetches an oauth2 token using the owner flow
+   * Sets up the oauth object that will be part of the overall
+   * Ketting object
    *
-   * @async
    * @param {object} ketting - Ketting object.
+   * @param {object} auth - Auth options object
    * @return {object}
    */
-  ownerFlow: function(ketting) {
-    return ketting.auth.oauthClient.owner.getToken(
-      ketting.auth.owner.userName,
-      ketting.auth.owner.password
-    )
-      .then(function (client) {
-        ketting.auth.accessToken = client.accessToken;
-        ketting.auth.refreshToken = client.refreshToken;
-        return ketting;
-      });
+  setupOAuthObject: function(ketting, auth) {
+    var oAuthObject = {
+      client: new ClientOAuth2(auth.client),
+      getToken: this.getToken,
+      refreshToken: this.refreshToken
+    };
+
+    if (auth.owner) {
+      oAuthObject.flow = 'owner';
+    }
+
+    return oAuthObject;
   }
 };

--- a/lib/utils/oauth.js
+++ b/lib/utils/oauth.js
@@ -87,10 +87,10 @@ module.exports = {
     throw new Error('Unsupported oauth2 flow');
   },
 
-  refreshToken : function(ketting) {
-    return ketting.auth.oauth.token.refresh()
+  refreshToken : function(auth) {
+    return auth.oauth.token.refresh()
       .then(function(updatedToken) {
-        ketting.auth.oauth.token = updatedToken;
+        auth.oauth.token = updatedToken;
         return;
       });
   },
@@ -103,10 +103,15 @@ module.exports = {
    * @return {object}
    */
   setupOAuthObject : function(auth) {
+    var oauth = this;
     var oAuthObject = {
       client: new ClientOAuth2(auth.client),
-      getToken: this.getToken,
-      refreshToken: this.refreshToken
+      getToken: function() {
+        return oauth.getToken(auth);
+      },
+      refreshToken: function() {
+        return oauth.refreshToken(auth);
+      }
     };
 
     if (auth.owner) {

--- a/lib/utils/oauth.js
+++ b/lib/utils/oauth.js
@@ -1,5 +1,7 @@
 var ClientOAuth2 = require('client-oauth2');
 
+var fetch = require('./fetch');
+
 /**
  * Fetches an oauth2 token using the owner flow
  *
@@ -18,7 +20,58 @@ function ownerFlow(auth) {
     });
 }
 
+/**
+ * Makes a request using OAuth2 when we have a token already.
+ *
+ * If the initial request fails with a 401 error, we assume the token headers
+ * expired. We refresh the token and attempt the request one more time.
+ *
+ * @async
+ * @param {object} ketting - Ketting object.
+ * @param {Request} request - Request object.
+ * @param {object} init - A list of settings.
+ * @return {object}
+ */
+function fetchWithAccessToken(ketting, request, init) {
+  request.headers.set('Authorization', 'Bearer ' + ketting.auth.oauth.token.accessToken);
+
+  return fetch(request, init)
+    .then(function(response) {
+      // If we receive 401, refresh token and try again once
+      if (!response.ok && response.status === 401) {
+        return ketting.auth.oauth.refreshToken(ketting)
+          .then(function() {
+            request.headers.set('Authorization', 'Bearer ' + ketting.auth.oauth.token.accessToken);
+            return fetch(request, init);
+          });
+      }
+
+      return response;
+    });
+}
+
 module.exports = {
+  /**
+   * Makes a request using OAuth2
+   *
+   * @async
+   * @param {object} ketting - Ketting object.
+   * @param {Request} request - Request object.
+   * @param {object} init - A list of settings.
+   * @return {object}
+   */
+  fetch : function(ketting, request, init) {
+    if (ketting.auth.oauth.token) {
+      return fetchWithAccessToken(ketting, request, init);
+    }
+
+    return this.getToken(ketting.auth)
+      .then(function () {
+        // Just call the ketting function again now that we have an access token
+        return fetch(request, init);
+      });
+  },
+
   /**
    * Fetches an oauth2 token and sets it on the given auth object
    *
@@ -26,7 +79,7 @@ module.exports = {
    * @param {object} auth - Auth object.
    * @return {object}
    */
-  getToken: function(auth) {
+  getToken : function(auth) {
     if (auth.oauth.flow === 'owner') {
       return ownerFlow(auth);
     }
@@ -34,7 +87,7 @@ module.exports = {
     throw new Error('Unsupported oauth2 flow');
   },
 
-  refreshToken: function(ketting) {
+  refreshToken : function(ketting) {
     return ketting.auth.oauth.token.refresh()
       .then(function(updatedToken) {
         ketting.auth.oauth.token = updatedToken;
@@ -46,11 +99,10 @@ module.exports = {
    * Sets up the oauth object that will be part of the overall
    * Ketting object
    *
-   * @param {object} ketting - Ketting object.
    * @param {object} auth - Auth options object
    * @return {object}
    */
-  setupOAuthObject: function(ketting, auth) {
+  setupOAuthObject : function(auth) {
     var oAuthObject = {
       client: new ClientOAuth2(auth.client),
       getToken: this.getToken,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ketting",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -209,6 +209,11 @@
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -382,6 +387,12 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -454,6 +465,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.2",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -493,6 +505,14 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "client-oauth2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/client-oauth2/-/client-oauth2-4.1.0.tgz",
+      "integrity": "sha1-t284FtIf9/5Lfm62nqujPiixdLY=",
+      "requires": {
+        "popsicle": "9.1.0"
+      }
+    },
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
@@ -518,6 +538,18 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
+    "co-body": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/co-body/-/co-body-5.1.1.tgz",
+      "integrity": "sha1-2XeB0eM0S6SoIP0YBr3fg0FQUjY=",
+      "dev": true,
+      "requires": {
+        "inflation": "2.0.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "1.6.15"
+      }
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -539,6 +571,14 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
@@ -558,7 +598,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
@@ -602,11 +641,16 @@
         "keygrip": "1.0.1"
       }
     },
+    "copy-to": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/copy-to/-/copy-to-2.0.1.tgz",
+      "integrity": "sha1-JoD7uAaKSNCGVrYJgJK9r8kG9KU=",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "create-ecdh": {
       "version": "4.0.0",
@@ -738,6 +782,11 @@
         "pinkie-promise": "2.0.1",
         "rimraf": "2.6.1"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -1278,6 +1327,16 @@
         "for-in": "1.0.2"
       }
     },
+    "form-data": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.16"
+      }
+    },
     "fresh": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
@@ -1289,6 +1348,905 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.7.0",
+        "node-pre-gyp": "0.6.36"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.36",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -1510,6 +2468,12 @@
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
+    "inflation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.0.0.tgz",
+      "integrity": "sha1-i0F+R8KPklpFEz2RTKH9OJEH8w8=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1523,8 +2487,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "3.2.3",
@@ -1752,8 +2715,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -1876,6 +2838,16 @@
         "statuses": "1.3.1",
         "type-is": "1.6.15",
         "vary": "1.1.1"
+      }
+    },
+    "koa-bodyparser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/koa-bodyparser/-/koa-bodyparser-4.2.0.tgz",
+      "integrity": "sha1-vObgi8Zfhwm20fqpQRx/DYk4qlQ=",
+      "dev": true,
+      "requires": {
+        "co-body": "5.1.1",
+        "copy-to": "2.0.1"
       }
     },
     "koa-compose": {
@@ -2095,6 +3067,19 @@
         "yallist": "2.1.2"
       }
     },
+    "make-error": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
+      "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y="
+    },
+    "make-error-cause": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
+      "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
+      "requires": {
+        "make-error": "1.3.0"
+      }
+    },
     "md5.js": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
@@ -2176,14 +3161,12 @@
     "mime-db": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
-      "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
-      "dev": true
+      "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
     },
     "mime-types": {
       "version": "2.1.16",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
       "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
-      "dev": true,
       "requires": {
         "mime-db": "1.29.0"
       }
@@ -2292,6 +3275,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
+      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+      "dev": true,
+      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -4324,6 +5314,17 @@
       "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
       "dev": true
     },
+    "popsicle": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-9.1.0.tgz",
+      "integrity": "sha1-T5APONV6V07BcO2kBJbjZAgr/2Y=",
+      "requires": {
+        "concat-stream": "1.6.0",
+        "form-data": "2.3.1",
+        "make-error-cause": "1.2.2",
+        "tough-cookie": "2.3.3"
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -4345,8 +5346,7 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
       "version": "2.0.0",
@@ -4382,7 +5382,12 @@
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
       "dev": true
     },
     "querystring": {
@@ -4447,6 +5452,26 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "raw-body": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+          "dev": true
+        }
+      }
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -4472,7 +5497,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -4615,8 +5639,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sax": {
       "version": "1.2.4",
@@ -4788,7 +5811,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -4894,6 +5916,14 @@
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
     "tryit": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
@@ -4934,8 +5964,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -4979,6 +6008,12 @@
         "uglify-js": "2.8.29",
         "webpack-sources": "1.0.1"
       }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
     },
     "uri-template": {
       "version": "1.0.1",
@@ -5026,8 +6061,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dist/ketting.min.js.map"
   ],
   "dependencies": {
+    "client-oauth2": "^4.1.0",
     "http-link-header": "^0.8.0",
     "node-fetch": "^1.7.3",
     "sax": "^1.2.4",
@@ -40,6 +41,7 @@
     "chai": "^4.1.2",
     "eslint": "^4.6.1",
     "koa": "^2.2.0",
+    "koa-bodyparser": "^4.2.0",
     "koa-logger": "^3.0.1",
     "koa-path-match": "^2.0.0",
     "mocha": "^3.5.2",

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ and discover resources and features on the server.
 
 ### Following links
 
-One core tennet of building a good REST service, is that URIs should be
+One core tenet of building a good REST service, is that URIs should be
 discovered, not hardcoded in an application. It's for this reason that the
 emphasis in this library is _not_ on URIs (like most libraries) but on
 relation-types (the `rel`) and links.
@@ -72,7 +72,7 @@ that uri, the api returns `201 Created` along with a `Location` header pointing
 to the new article. On this location, a new `rel="author"` appears
 automatically, pointing to the person that created the article.
 
-This is how that iteraction might look like:
+This is how that interaction might look like:
 
 ```js
 var ketting = new Ketting('https://api.example.org/');
@@ -87,7 +87,7 @@ console.log(await author.get());
 
 ### Embedded resources
 
-Embedded resources are a HAL feature. In situations when you are modelling a
+Embedded resources are a HAL feature. In situations when you are modeling a
 'collection' of resources, in HAL you should generally just create links to
 all the items in the collection. However, if a client wants to fetch all these
 items, this can result in a lot of HTTP requests. HAL uses `_embedded` to work
@@ -161,9 +161,7 @@ var ketting = new Ketting('https://api.example.org/', options);
 ```
 
 2 keys or `options` are currently supported: `auth` and `fetchInit`.  `auth`
-can be used to specify authentication information. HTTP Basic auth and OAUth2
-Bearer token are
-supported.
+can be used to specify authentication information. Support authentication methods are: HTTP Basic auth, OAuth2 Bearer tokens, and OAuth2 managed client.
 
 Basic example:
 
@@ -177,7 +175,7 @@ var options = {
 };
 ```
 
-Bearer example:
+OAuth2 Bearer example:
 
 ```js
 var options = {
@@ -188,12 +186,33 @@ var options = {
 };
 ```
 
+##### OAuth2 Managed Client
+The only currently supported authorization flow is the [Resource Owner Password Credentials Grant](https://tools.ietf.org/html/rfc6749#section-4.3).
+
+Resource Owner Password Credentials Grant example:
+
+```js
+var options = auth: {
+  type: 'oauth2',
+  client: {
+    clientId: 'fooClient',
+    clientSecret: 'barSecret',
+    accessTokenUri: 'https://api.example.org//oauth/token',
+    scopes: ['test']
+  },
+  owner: {
+    userName: 'fooOwner',
+    password: 'barPassword'
+  }
+}
+```
+
 The `fetchInit` option is a default list of settings that's automatically
 passed to `fetch()`. This is especially useful in a browser, where there's a
 few more settings highly relevant to the security sandbox.
 
 For example, to ensure that the browser automatically passed relevant cookies
-to the endpoint, you would specifiy this as such:
+to the endpoint, you would specify this as such:
 
 ```js
 var options = {
@@ -393,7 +412,7 @@ For example, this is how you might do a HTTP `PATCH` request:
 ```js
 var init = {
   method: 'PATCH',
-  body: JSON.serialize(['some', 'patch, 'object'])
+  body: JSON.serialize(['some', 'patch', 'object'])
 };
 var response = await resource.fetch(init);
 console.log(response.statusCode);
@@ -402,7 +421,7 @@ console.log(response.statusCode);
 #### `resource.fetchAndThrow()`
 
 This function is identical to `fetch`, except that it will throw a (async)
-exception if the server responsed with a HTTP error.
+exception if the server responded with a HTTP error.
 
 ### Link
 
@@ -414,7 +433,7 @@ following properties:
 * baseHref - the uri of the parent document. Used for resolving relative uris.
 * type - A mimetype, if specified
 * templated - If it's a URI Template. Most of the time this is false.
-* title - Hunman readable label for the uri
+* title - Human readable label for the uri
 * name - Unique identifier for the link within the document (rarely used).
 
 #### `Link.resolve()`
@@ -438,6 +457,35 @@ var link = new Link({href: 'http://example.org/foo{?q}', templated: true});
 console.log(link.expand({q: 'bla bla'});
 // output is http://example.org/foo?q=bla+bla
 ```
+
+### OAuth2 Managed Client
+The underlying OAuth2 client is implemented using [js-client-oauth2](https://github.com/mulesoft/js-client-oauth2) and is exposed via the 'Ketting' class.
+```js
+var ketting = new Ketting('https://api.example.org/', {
+  auth: {
+    type: 'oauth2',
+    client: {
+      clientId: 'fooClient',
+      clientSecret: 'barSecret',
+      accessTokenUri: 'https://api.example.org/oauth/token',
+      scopes: ['test']
+    },
+    owner: {
+      userName: 'fooOwner',
+      password: 'barPassword'
+    }
+  }
+});
+
+var oAuthClient = ketting.auth.oauth.client;
+// Interact with the underlying OAuth2 client
+
+
+// Helper functions are also exposed for fetching and refreshing the access token
+ketting.auth.oauth.getToken();
+ketting.auth.oauth.refreshToken();
+```
+
 
 [1]: https://tools.ietf.org/html/rfc5988 "Web Linking"
 [2]: http://stateless.co/hal_specification.html "HAL - Hypertext Application Language"

--- a/readme.md
+++ b/readme.md
@@ -160,8 +160,12 @@ var options = {}; // options are optional
 var ketting = new Ketting('https://api.example.org/', options);
 ```
 
-2 keys or `options` are currently supported: `auth` and `fetchInit`.  `auth`
-can be used to specify authentication information. Support authentication methods are: HTTP Basic auth, OAuth2 Bearer tokens, and OAuth2 managed client.
+2 keys or `options` are currently supported: `auth` and `fetchInit`.  
+
+`auth` can be used to specify authentication information. Supported authentication methods are:
+- HTTP Basic auth
+- OAuth2 Bearer tokens
+- OAuth2 managed client
 
 Basic example:
 
@@ -197,7 +201,7 @@ var options = auth: {
   client: {
     clientId: 'fooClient',
     clientSecret: 'barSecret',
-    accessTokenUri: 'https://api.example.org//oauth/token',
+    accessTokenUri: 'https://api.example.org/oauth/token',
     scopes: ['test']
   },
   owner: {

--- a/test/fixtures/hal1.json
+++ b/test/fixtures/hal1.json
@@ -9,6 +9,7 @@
         "echo": { "href" : "/echo" },
         "auth-basic" : { "href" : "/auth/basic" },
         "auth-bearer" : { "href" : "/auth/bearer" },
+        "auth-oauth" : { "href" : "/auth/oauth" },
         "templated" : { "href" : "/templated.json{?foo}", "templated": true },
         "linkHeader" : { "href" : "/link-header" },
         "problem" : { "href" : "/problem" },

--- a/test/integration/bearer-auth.js
+++ b/test/integration/bearer-auth.js
@@ -3,10 +3,10 @@ const Resource = require('../../lib/resource');
 const expect = require('chai').expect;
 const Request = require('node-fetch').Request;
 
-describe('OAuth Authentication', () => {
+describe('Bearer Authentication', () => {
 
   it('should return 401 if no credentials were passed.', async() => {
-  
+
     const ketting = new Ketting('http://localhost:3000/hal1.json');
     const resource = await ketting.follow('auth-bearer');
     const response = await resource.fetch();
@@ -20,7 +20,7 @@ describe('OAuth Authentication', () => {
       auth: {
         type: 'bearer',
         token: 'bar'
-      } 
+      }
     });
     const resource = await ketting.follow('auth-bearer');
     const response = await resource.fetch();
@@ -34,7 +34,7 @@ describe('OAuth Authentication', () => {
       auth: {
         type: 'bearer',
         token: 'foo'
-      } 
+      }
     });
     const resource = await ketting.follow('auth-bearer');
     const response = await resource.fetch();

--- a/test/integration/oauth-auth.js
+++ b/test/integration/oauth-auth.js
@@ -1,0 +1,91 @@
+const Ketting = require('../../lib/ketting');
+const Resource = require('../../lib/resource');
+const expect = require('chai').expect;
+const Request = require('node-fetch').Request;
+
+describe('OAuth2 Authentication', () => {
+
+  it('should return 401 if no credentials were passed.', async() => {
+
+    const ketting = new Ketting('http://localhost:3000/hal1.json');
+    const resource = await ketting.follow('auth-oauth');
+    const response = await resource.fetch();
+    expect(response.status).to.eql(401);
+
+  });
+
+  it('should throw error if incorrect client credentials were passed.', (done) => {
+
+    const ketting = new Ketting('http://localhost:3000/hal1.json', {
+      auth: {
+        type: 'oauth2',
+        client: {
+          clientId: 'fooClient',
+          clientSecret: 'fooSecret',
+          accessTokenUri: 'http://localhost:3000/oauth-token',
+          scopes: ['test']
+        },
+        owner: {
+          userName: 'fooOwner',
+          password: 'barPassword'
+        }
+      }
+    });
+    ketting.follow('auth-oauth')
+      .catch((error) => {
+        expect(error).to.be.an('error');
+        done();
+      });
+
+  });
+
+  it('should return 401 if incorrect owner credentials were passed.', (done) => {
+
+    const ketting = new Ketting('http://localhost:3000/hal1.json', {
+      auth: {
+        type: 'oauth2',
+        client: {
+          clientId: 'fooClient',
+          clientSecret: 'barSecret',
+          accessTokenUri: 'http://localhost:3000/oauth-token',
+          scopes: ['test']
+        },
+        owner: {
+          userName: 'fooOwner',
+          password: 'fooPassword'
+        }
+      }
+    });
+    ketting.follow('auth-oauth')
+      .catch((error) => {
+        expect(error).to.be.an('error');
+        done();
+      });
+
+  });
+
+  it('should return 200 OK if correct credentials were passed.', async() => {
+
+    const ketting = new Ketting('http://localhost:3000/hal1.json', {
+      auth: {
+        type: 'oauth2',
+        client: {
+          clientId: 'fooClient',
+          clientSecret: 'barSecret',
+          accessTokenUri: 'http://localhost:3000/oauth-token',
+          scopes: ['test']
+        },
+        owner: {
+          userName: 'fooOwner',
+          password: 'barPassword'
+        }
+      }
+    });
+
+    const resource = await ketting.follow('auth-oauth');
+    const response = await resource.fetch();
+    expect(response.status).to.eql(200);
+
+  });
+
+});

--- a/test/integration/oauth-auth.js
+++ b/test/integration/oauth-auth.js
@@ -5,42 +5,93 @@ const Request = require('node-fetch').Request;
 
 describe('OAuth2 Authentication', () => {
 
-  it('should return 401 if no credentials were passed.', async() => {
+  describe('Owner flow', () => {
 
-    const ketting = new Ketting('http://localhost:3000/hal1.json');
-    const resource = await ketting.follow('auth-oauth');
-    const response = await resource.fetch();
-    expect(response.status).to.eql(401);
+    it('should return 401 if no credentials were passed.', async() => {
 
-  });
+      const ketting = new Ketting('http://localhost:3000/hal1.json');
+      const resource = await ketting.follow('auth-oauth');
+      const response = await resource.fetch();
+      expect(response.status).to.eql(401);
 
-  it('should throw error if incorrect client credentials were passed.', (done) => {
-
-    const ketting = new Ketting('http://localhost:3000/hal1.json', {
-      auth: {
-        type: 'oauth2',
-        client: {
-          clientId: 'fooClient',
-          clientSecret: 'fooSecret',
-          accessTokenUri: 'http://localhost:3000/oauth-token',
-          scopes: ['test']
-        },
-        owner: {
-          userName: 'fooOwner',
-          password: 'barPassword'
-        }
-      }
     });
-    ketting.follow('auth-oauth')
-      .catch((error) => {
-        expect(error).to.be.an('error');
-        done();
+
+    it('should throw error if incorrect client credentials were passed.', (done) => {
+
+      const ketting = new Ketting('http://localhost:3000/hal1.json', {
+        auth: {
+          type: 'oauth2',
+          client: {
+            clientId: 'fooClient',
+            clientSecret: 'fooSecret',
+            accessTokenUri: 'http://localhost:3000/oauth-token',
+            scopes: ['test']
+          },
+          owner: {
+            userName: 'fooOwner',
+            password: 'barPassword'
+          }
+        }
+      });
+      ketting.follow('auth-oauth')
+        .catch((error) => {
+          expect(error).to.be.an('error');
+          done();
+        });
+
+    });
+
+    it('should return 401 if incorrect owner credentials were passed.', (done) => {
+
+      const ketting = new Ketting('http://localhost:3000/hal1.json', {
+        auth: {
+          type: 'oauth2',
+          client: {
+            clientId: 'fooClient',
+            clientSecret: 'barSecret',
+            accessTokenUri: 'http://localhost:3000/oauth-token',
+            scopes: ['test']
+          },
+          owner: {
+            userName: 'fooOwner',
+            password: 'fooPassword'
+          }
+        }
+      });
+      ketting.follow('auth-oauth')
+        .catch((error) => {
+          expect(error).to.be.an('error');
+          done();
+        });
+
+    });
+
+    it('should return 200 OK if correct credentials were passed.', async() => {
+
+      const ketting = new Ketting('http://localhost:3000/hal1.json', {
+        auth: {
+          type: 'oauth2',
+          client: {
+            clientId: 'fooClient',
+            clientSecret: 'barSecret',
+            accessTokenUri: 'http://localhost:3000/oauth-token',
+            scopes: ['test']
+          },
+          owner: {
+            userName: 'fooOwner',
+            password: 'barPassword'
+          }
+        }
       });
 
+      const resource = await ketting.follow('auth-oauth');
+      const response = await resource.fetch();
+      expect(response.status).to.eql(200);
+
+    });
   });
 
-  it('should return 401 if incorrect owner credentials were passed.', (done) => {
-
+  it('should throw error when using unsupported flow', (done) => {
     const ketting = new Ketting('http://localhost:3000/hal1.json', {
       auth: {
         type: 'oauth2',
@@ -50,42 +101,17 @@ describe('OAuth2 Authentication', () => {
           accessTokenUri: 'http://localhost:3000/oauth-token',
           scopes: ['test']
         },
-        owner: {
-          userName: 'fooOwner',
-          password: 'fooPassword'
+        foo: {
+          bar: ''
         }
       }
     });
     ketting.follow('auth-oauth')
       .catch((error) => {
         expect(error).to.be.an('error');
+        expect(error.message).to.equal('Unsupported oauth2 flow');
         done();
       });
-
-  });
-
-  it('should return 200 OK if correct credentials were passed.', async() => {
-
-    const ketting = new Ketting('http://localhost:3000/hal1.json', {
-      auth: {
-        type: 'oauth2',
-        client: {
-          clientId: 'fooClient',
-          clientSecret: 'barSecret',
-          accessTokenUri: 'http://localhost:3000/oauth-token',
-          scopes: ['test']
-        },
-        owner: {
-          userName: 'fooOwner',
-          password: 'barPassword'
-        }
-      }
-    });
-
-    const resource = await ketting.follow('auth-oauth');
-    const response = await resource.fetch();
-    expect(response.status).to.eql(200);
-
   });
 
 });

--- a/test/integration/oauth-auth.js
+++ b/test/integration/oauth-auth.js
@@ -89,6 +89,71 @@ describe('OAuth2 Authentication', () => {
       expect(response.status).to.eql(200);
 
     });
+
+    it('should refresh token if 401 is returned and retry request', async() => {
+
+      const ketting = new Ketting('http://localhost:3000/hal1.json', {
+        auth: {
+          type: 'oauth2',
+          client: {
+            clientId: 'fooClient',
+            clientSecret: 'barSecret',
+            accessTokenUri: 'http://localhost:3000/oauth-token',
+            scopes: ['test']
+          },
+          owner: {
+            userName: 'fooOwner',
+            password: 'barPassword'
+          }
+        }
+      });
+
+      const token = ketting.auth.oauth.client.createToken(
+        'barToken',
+        'fooRefresh',
+        'bearer'
+      );
+      ketting.auth.oauth.token = token;
+
+      const resource = await ketting.follow('auth-oauth');
+      const response = await resource.fetch();
+      expect(response.status).to.eql(200);
+
+    });
+
+    it('should refresh token if 401 is returned and throw error if refresh is invalid', async() => {
+
+      const ketting = new Ketting('http://localhost:3000/hal1.json', {
+        auth: {
+          type: 'oauth2',
+          client: {
+            clientId: 'fooClient',
+            clientSecret: 'barSecret',
+            accessTokenUri: 'http://localhost:3000/oauth-token',
+            scopes: ['test']
+          },
+          owner: {
+            userName: 'fooOwner',
+            password: 'barPassword'
+          }
+        }
+      });
+
+      const token = ketting.auth.oauth.client.createToken(
+        'barToken',
+        'barRefresh',
+        'bearer'
+      );
+      ketting.auth.oauth.token = token;
+
+      try {
+        const resource = await ketting.follow('auth-oauth');
+        const response = await resource.fetch();
+
+      } catch (error){
+        expect(error).to.be.an('error');
+      }
+    });
   });
 
   it('should throw error when using unsupported flow', (done) => {
@@ -106,6 +171,7 @@ describe('OAuth2 Authentication', () => {
         }
       }
     });
+
     ketting.follow('auth-oauth')
       .catch((error) => {
         expect(error).to.be.an('error');

--- a/test/testserver.js
+++ b/test/testserver.js
@@ -162,9 +162,19 @@ app.use(
     .post(ctx => {
       const requestBody = ctx.request.body;
       const clientInfo = Buffer.from(ctx.request.headers.authorization.split(' ')[1], 'base64').toString('ascii');
+
+      // Check that the client info is legitimate an then check if the user
+      // information is correct if a password grant or the refresh token is
+      // valid if doing a refresh grant
       if (clientInfo === 'fooClient:barSecret'
-        && requestBody.username === 'fooOwner'
-        && requestBody.password === 'barPassword'
+        && (
+          (requestBody.grant_type === 'password'
+          && requestBody.username === 'fooOwner'
+          && requestBody.password === 'barPassword')
+        ||
+          (requestBody.grant_type === 'refresh_token'
+          && requestBody.refresh_token === 'fooRefresh')
+        )
       ){
         ctx.response.body = {
           token_type: 'bearer',


### PR DESCRIPTION
This is work for #19.

@evert,
I've added a new auth type: `oauth2` and support for the owner flow. What I've done so far is to just request the authorization token when it is missing and set it in the ketting object. You can see in the new tests how configuring this works. This makes use of https://github.com/mulesoft/js-client-oauth2 for managing the oauth client.

I still need to add support for refreshing the token and updating the docs, but I'd like to get your initial thoughts.