### PR TITLE
Also publish types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ build: browser/ketting.min.js browser/mocha-tests.js tsbuild
 clean:
 	-rm -r browser/
 	-rm -r dist/
-	-rm -rf node_modules/
 
 .PHONY: test
 test: lint
@@ -22,11 +21,11 @@ lint:
 	eslint src/
 
 .PHONY: tsbuild
-tsbuild: node_modules
+tsbuild:
 	tsc
 
 .PHONY: watch
-watch: node_modules
+watch:
 	tsc --watch
 
 .PHONY: browserbuild
@@ -41,9 +40,6 @@ browerbuild:
 
 browser/ketting.min.js: browserbuild
 browser/mocha-tests.js: browserbuild
-
-node_modules: package-lock.json
-	npm install
 
 testserver: build
 	cd test; node testserver.js

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "browser/ketting.min.js",
     "browser/ketting.min.js.map"
   ],
+  "types": "dist/index.d.ts",
   "dependencies": {
     "client-oauth2": "^4.2.1",
     "cross-fetch": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "homepage": "https://github.com/evert/ketting#readme",
   "files": [
-    "src",
     "dist/",
     "browser/ketting.min.js",
     "browser/ketting.min.js.map"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
         "sourceMap": true,
         "outDir": "dist",
         "baseUrl": ".",
-        "allowJs": true,
         "paths": {
             "*": [
                 "src/types/*"
@@ -29,7 +28,9 @@
           "ES2016",
           "ES2017",
           "DOM.Iterable"
-        ]
+        ],
+
+        "declaration": true
     },
     "include": [
         "src/**/*"


### PR DESCRIPTION
* No longer allowing non-typescript.
* Automatically publish types.
* No longer publish `.ts` files in npm package.