### PR TITLE
Basic JSON:API support.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 ChangeLog
 =========
 
+2.5.0 (????-??-??)
+------------------
+
+* Basic JSON:API support. Currently only links appearing in the top-level
+  document are supported.
+
+
 2.4.1 (2018-11-07)
 ------------------
 

--- a/src/ketting.ts
+++ b/src/ketting.ts
@@ -2,6 +2,7 @@ import FollowablePromise from './followable-promise';
 import Representor from './representor/base';
 import HalRepresentor from './representor/hal';
 import HtmlRepresentor from './representor/html';
+import JsonApiRepresentor from './representor/jsonapi';
 import Resource from './resource';
 import * as base64 from './utils/base64';
 import * as fetchHelper from './utils/fetch-helper';
@@ -99,14 +100,19 @@ export default class Ketting {
         q: '1.0',
       },
       {
+        mime: 'application/vnd.api+json',
+        representor: 'jsonapi',
+        q: '0.9',
+      },
+      {
         mime: 'application/json',
         representor: 'hal',
-        q: '0.9',
+        q: '0.8',
       },
       {
         mime: 'text/html',
         representor: 'html',
-        q: '0.8',
+        q: '0.7',
       }
     ];
 
@@ -215,9 +221,11 @@ export default class Ketting {
 
     switch (result.representor) {
     case 'html' :
-      return HtmlRepresentor;
+        return HtmlRepresentor;
     case 'hal' :
-      return HalRepresentor;
+        return HalRepresentor;
+    case 'jsonapi' :
+        return JsonApiRepresentor;
     default :
       throw new Error('Unknown representor: ' + result.representor);
 

--- a/src/representor/jsonapi.ts
+++ b/src/representor/jsonapi.ts
@@ -1,0 +1,86 @@
+import Link from '../link';
+// import { resolve } from '../utils/url';
+import Representation from './base';
+
+/**
+ * A JSON:API link can either be a string, or an object with at least a href
+ * property.
+ */
+type JsonApiLink = string | { href: string };
+
+/**
+ * This type represents a valid JSON:API response. We're only interested
+ * in the links object at the moment, so everything else is (for now)
+ * untyped.
+ */
+type JsonApiObject = {
+  links?: {
+    [rel: string]: JsonApiLink | JsonApiLink[]
+  },
+  [s: string]: any
+};
+
+/**
+ * This class represents JSON:API responses.
+ *
+ * The Representor is responsible from extracting any links from the body,
+ * so they can be followed.
+ */
+export default class JsonApi extends Representation {
+
+  body: JsonApiObject;
+
+  constructor(uri: string, contentType: string, body: any) {
+
+    super(uri, contentType, body);
+
+    if (typeof body === 'string') {
+      this.body = JSON.parse(body);
+    } else {
+      this.body = body;
+    }
+
+    this.links = parseJsonApiLinks(uri, this.body);
+
+  }
+
+}
+
+/**
+ * This function takes a JSON:API object, and extracts the links property.
+ */
+function parseJsonApiLinks(baseHref: string, body: JsonApiObject): Link[] {
+
+  const result: Link[] = [];
+
+  if (body.links === undefined) {
+    return result;
+  }
+
+  for (const [rel, linkValue] of Object.entries(body.links)) {
+
+    if (Array.isArray(linkValue)) {
+      result.push(...linkValue.map( link => parseJsonApiLink(baseHref, rel, link)));
+    } else {
+      result.push(parseJsonApiLink(baseHref, rel, linkValue));
+    }
+
+  }
+
+  return result;
+
+}
+
+/**
+ * This function takes a single link value from a JSON:API link object, and
+ * returns a object of type Link
+ */
+function parseJsonApiLink(baseHref: string, rel: string, link: JsonApiLink): Link {
+
+  return new Link({
+    baseHref,
+    rel,
+    href: typeof link === 'string' ? link : link.href,
+  });
+
+}

--- a/test/fixtures/hal1.json
+++ b/test/fixtures/hal1.json
@@ -22,7 +22,8 @@
             "templated": true
           }
         ],
-        "content-type-link" : { "href" : "/hal2.json", "type": "application/foo+json" }
+        "content-type-link" : { "href" : "/hal2.json", "type": "application/foo+json" },
+        "json-api" : { "href" : "/json-api.json", "type": "application/vnd.api+json" }
     },
     "title"  : "Hal 1",
     "foo" : "bar"

--- a/test/fixtures/json-api.json
+++ b/test/fixtures/json-api.json
@@ -1,0 +1,5 @@
+{
+  "links" : {
+    "next": "https://example.org/next-jsonapi"
+  }
+}

--- a/test/integration/follow-jsonapi.ts
+++ b/test/integration/follow-jsonapi.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import Ketting from '../../src/ketting';
+import Resource from '../../src/resource';
+import JsonApiRepresentor from '../../src/representor/jsonapi';
+
+describe('Following a JSON API link', async () => {
+
+  const ketting = new Ketting('http://localhost:3000/hal1.json');
+
+  let jsonapi: Resource;
+
+  it('should return a resource', async () => {
+
+    jsonapi = await ketting.follow('json-api');
+    expect(jsonapi).to.be.an.instanceof(Resource);
+
+
+  });
+  it('should use the JSON:API representor', async () => {
+
+    const rep = await jsonapi.representation();
+    expect(rep).to.be.an.instanceof(JsonApiRepresentor);
+
+  });
+  it('should allow following links further', async () => {
+    
+    console.log(await jsonapi.links());
+    const next = await jsonapi.follow('next');
+    expect(next.uri).to.equal('https://example.org/next-jsonapi');
+
+  });
+});

--- a/test/integration/get.ts
+++ b/test/integration/get.ts
@@ -25,7 +25,7 @@ describe('Issuing a GET request', async () => {
 
     expect(result).to.have.property('user-agent');
     expect(result['user-agent']).to.match(/^Ketting\//);
-    expect(result.accept).to.eql('application/hal+json;q=1.0, application/json;q=0.9, text/html;q=0.8');
+    expect(result.accept).to.eql('application/hal+json;q=1.0, application/vnd.api+json;q=0.9, application/json;q=0.8, text/html;q=0.7');
 
   });
 

--- a/test/testserver.ts
+++ b/test/testserver.ts
@@ -229,7 +229,12 @@ app.use(
       ctx.response.body = '';
       return;
     }
-    ctx.response.type = 'application/json';
+    // The test server needs cleanup :(
+    if (ctx.params.id.includes('json-api')) {
+      ctx.response.type = 'application/vnd.api+json';
+    } else {
+      ctx.response.type = 'application/json';
+    }
     ctx.response.body = resources[ctx.params.id];
 
   })

--- a/test/unit/representor/jsonapi.ts
+++ b/test/unit/representor/jsonapi.ts
@@ -1,0 +1,110 @@
+import { expect } from 'chai';
+import Link from '../../../src/link';
+import JsonApi from '../../../src/representor/jsonapi';
+
+describe('JsonApi representor', () => {
+
+  it('should parse objects without links' , () => {
+
+    const r = new JsonApi('/foo.json', 'application/vnd.api+json', '{"foo": "bar"}');
+    expect(r.contentType).to.equal('application/vnd.api+json');
+    expect(r.body).to.eql({foo: 'bar'});
+    expect(r.links.length).to.equal(0);
+
+  });
+
+  it('should parse simple string links' , () => {
+
+    const input = {
+      links: {
+        example: 'https://example.org',
+      }
+    };
+    const r = new JsonApi('/foo.json', 'application/vnd.api+json', input);
+    expect(r.contentType).to.equal('application/vnd.api+json');
+    expect(r.links).to.eql([
+      new Link({
+        baseHref: '/foo.json',
+        href: 'https://example.org',
+        rel: 'example',
+      })
+    ]);
+
+  });
+
+  it('should parse arrays of string links' , () => {
+
+    const input = {
+      links: {
+        example: [
+          'https://example.org',
+          'https://example.com',
+        ]
+      }
+    };
+    const r = new JsonApi('/foo.json', 'application/vnd.api+json', input);
+    expect(r.contentType).to.equal('application/vnd.api+json');
+    expect(r.links).to.eql([
+      new Link({
+        baseHref: '/foo.json',
+        href: 'https://example.org',
+        rel: 'example',
+      }),
+      new Link({
+        baseHref: '/foo.json',
+        href: 'https://example.com',
+        rel: 'example',
+      })
+    ]);
+
+  });
+
+  it('should parse object links' , () => {
+
+    const input = {
+      links: {
+        example: {
+          href: 'https://example.org'
+        },
+      }
+    };
+    const r = new JsonApi('/foo.json', 'application/vnd.api+json', input);
+    expect(r.contentType).to.equal('application/vnd.api+json');
+    expect(r.links).to.eql([
+      new Link({
+        baseHref: '/foo.json',
+        href: 'https://example.org',
+        rel: 'example',
+      })
+    ]);
+
+  });
+
+  it('should parse arrays of object links' , () => {
+
+    const input = {
+      links: {
+        example: [
+          { href: 'https://example.org' },
+          { href: 'https://example.com' },
+        ]
+      }
+    };
+    const r = new JsonApi('/foo.json', 'application/vnd.api+json', input);
+    expect(r.contentType).to.equal('application/vnd.api+json');
+    expect(r.links).to.eql([
+      new Link({
+        baseHref: '/foo.json',
+        href: 'https://example.org',
+        rel: 'example',
+      }),
+      new Link({
+        baseHref: '/foo.json',
+        href: 'https://example.com',
+        rel: 'example',
+      })
+    ]);
+
+  });
+
+});


### PR DESCRIPTION
This PR adds some support for the JSON:API content-type. This change
will parse the "links" object from the top-level document.

links objects appearing deeper in the document are currently ignored.
I'm hoping this is a good first foundation. From this we might be able
to figure out what the next steps are for dealing with embedded items
and links objects appearing elsewhere in the document.

@gabesullice : mind reviewing this?

Related issues: #109 #111 