### PR TITLE
Renaming 'baseUri' to 'context'

### DIFF
--- a/src/link.ts
+++ b/src/link.ts
@@ -2,7 +2,7 @@ import * as uriTemplate from 'uri-template';
 import { resolve } from './utils/url';
 
 type LinkInit = {
-  baseHref: string,
+  context: string,
   href: string,
   name?: string,
   rel: string,
@@ -19,7 +19,7 @@ export default class Link {
   /**
    * The base href of the parent document. Used for expanding relative links.
    */
-  baseHref: string;
+  context: string;
 
   /**
    * The URI of the link. Might be relative
@@ -59,7 +59,7 @@ export default class Link {
     this.templated = false;
     this.title = null;
     this.type = null;
-    for (const key of ['baseHref', 'href', 'name', 'rel', 'templated', 'title', 'type']) {
+    for (const key of ['context', 'href', 'name', 'rel', 'templated', 'title', 'type']) {
       if ((<any> properties)[key]) {
         (<any> this)[key] = (<any> properties)[key];
       }
@@ -73,7 +73,7 @@ export default class Link {
    */
   resolve(): string {
 
-    return resolve(this.baseHref, this.href);
+    return resolve(this.context, this.href);
 
   }
 
@@ -86,11 +86,11 @@ export default class Link {
   expand(variables: object): string {
 
     if (!this.templated) {
-      return resolve(this.baseHref, this.href);
+      return resolve(this.context, this.href);
     } else {
       const templ = uriTemplate.parse(this.href);
       const expanded = templ.expand(variables);
-      return resolve(this.baseHref, expanded);
+      return resolve(this.context, expanded);
     }
 
   }

--- a/src/representor/hal.ts
+++ b/src/representor/hal.ts
@@ -70,7 +70,7 @@ const parseHalLink = (representation: Hal, rel: string, links: HalLink[]): void 
     representation.links.push(
       new Link({
         rel: rel,
-        baseHref: representation.uri,
+        context: representation.uri,
         href: link.href,
         title: link.title,
         type: link.type,
@@ -108,7 +108,7 @@ const parseHalEmbedded = (representation: Hal): void => {
         representation.links.push(
           new Link({
             rel: relType,
-            baseHref: representation.uri,
+            context: representation.uri,
             href: embeddedItem._links.self.href
           })
         );

--- a/src/representor/html.ts
+++ b/src/representor/html.ts
@@ -32,7 +32,7 @@ export default class Html extends Representation {
 
         const link = new Link({
           rel: rel,
-          baseHref: this.uri,
+          context: this.uri,
           href: <string> node.attributes.HREF,
           type: <string> node.attributes.TYPE || undefined
         });

--- a/src/representor/html.web.ts
+++ b/src/representor/html.web.ts
@@ -47,7 +47,7 @@ function linkFromTags(htmlDoc: Html, elements: HTMLCollectionOf<HTMLElement>) {
 
       const link = new Link({
         rel: rel,
-        baseHref: htmlDoc.uri,
+        context: htmlDoc.uri,
         href: href,
         type: type
       });

--- a/src/representor/jsonapi.ts
+++ b/src/representor/jsonapi.ts
@@ -116,7 +116,7 @@ function parseJsonApiCollection(baseHref: string, body: JsonApiTopLevelObject): 
 
       const selfLink = parseJsonApiLink(baseHref, 'self', member.links.self);
       result.push(new Link({
-        baseHref: baseHref,
+        context: baseHref,
         href: selfLink.href,
         rel: 'item'
       }));
@@ -135,7 +135,7 @@ function parseJsonApiCollection(baseHref: string, body: JsonApiTopLevelObject): 
 function parseJsonApiLink(baseHref: string, rel: string, link: JsonApiLink): Link {
 
   return new Link({
-    baseHref,
+    context: baseHref,
     rel,
     href: typeof link === 'string' ? link : link.href,
   });

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -231,7 +231,7 @@ export default class Resource<T = any> {
            this.repr.links.push(
               new Link({
                 rel: rel,
-                baseHref: this.uri,
+                context: this.uri,
                 href: httpLink.uri
               })
            );

--- a/test/integration/get.ts
+++ b/test/integration/get.ts
@@ -50,22 +50,22 @@ describe('Issuing a GET request', async () => {
     const expected = [
       new Link({
         rel: 'next',
-        baseHref: 'http://localhost:3000/link-header',
+        context: 'http://localhost:3000/link-header',
         href: '/hal2.json'
       }),
       new Link({
         rel: 'previous',
-        baseHref: 'http://localhost:3000/link-header',
+        context: 'http://localhost:3000/link-header',
         href: '/TheBook/chapter2'
       }),
       new Link({
         rel: 'start',
-        baseHref: 'http://localhost:3000/link-header',
+        context: 'http://localhost:3000/link-header',
         href: 'http://example.org/'
       }),
       new Link({
         rel: 'http://example.net/relation/other',
-        baseHref: 'http://localhost:3000/link-header',
+        context: 'http://localhost:3000/link-header',
         href: 'http://example.org/'
       })
     ];

--- a/test/unit/link.ts
+++ b/test/unit/link.ts
@@ -7,7 +7,7 @@ describe('Link', () => {
   it('should construct and expose its properties', () => {
 
     const link = new Link({
-      baseHref: 'http://example.org/',
+      context: 'http://example.org/',
       href: '/foo/bar',
       rel: 'foo',
 
@@ -18,7 +18,7 @@ describe('Link', () => {
     });
 
     expect(link.rel).to.equal('foo');
-    expect(link.baseHref).to.equal('http://example.org/');
+    expect(link.context).to.equal('http://example.org/');
     expect(link.href).to.equal('/foo/bar');
     expect(link.type).to.equal('text/css');
     expect(link.templated).to.equal(false);
@@ -31,7 +31,7 @@ describe('Link', () => {
 
     const link = new Link({
       rel: 'about',
-      baseHref: 'http://example.org/',
+      context: 'http://example.org/',
       href: '/foo/bar'
     });
 
@@ -42,7 +42,7 @@ describe('Link', () => {
   it('should be able to expand templated links', () => {
 
     const link = new Link({
-      baseHref: 'http://example.org/',
+      context: 'http://example.org/',
       href: '/foo/{bar}',
       rel: 'about',
       templated: true
@@ -55,7 +55,7 @@ describe('Link', () => {
   it('should not error when expanding non-templated links', () => {
 
     const link = new Link({
-      baseHref: 'http://example.org/',
+      context: 'http://example.org/',
       href: '/foo/bar',
       rel: 'about',
     });

--- a/test/unit/representor/html.ts
+++ b/test/unit/representor/html.ts
@@ -10,52 +10,52 @@ describe('HTML representor', () => {
   const tests: TestTuple[] = [
     [
       '<link rel="me" href="https://evertpot.com/" />',
-      new Link({rel: 'me', baseHref: '/index.html', href: 'https://evertpot.com/'})
+      new Link({rel: 'me', context: '/index.html', href: 'https://evertpot.com/'})
     ],
     [
       '<link rel="me" href="https://evertpot.com/">',
-      new Link({rel: 'me', baseHref: '/index.html', href: 'https://evertpot.com/'})
+      new Link({rel: 'me', context: '/index.html', href: 'https://evertpot.com/'})
     ],
     [
       '<LINK rel="me" href="https://evertpot.com/">',
-      new Link({rel: 'me', baseHref: '/index.html', href: 'https://evertpot.com/'})
+      new Link({rel: 'me', context: '/index.html', href: 'https://evertpot.com/'})
     ],
     [
       '<link REL="me" href="https://evertpot.com/">',
-      new Link({rel: 'me', baseHref: '/index.html', href: 'https://evertpot.com/'})
+      new Link({rel: 'me', context: '/index.html', href: 'https://evertpot.com/'})
     ],
     [
       '<link href="https://evertpot.com/" rel="me" />',
-      new Link({rel: 'me', baseHref: '/index.html', href: 'https://evertpot.com/'})
+      new Link({rel: 'me', context: '/index.html', href: 'https://evertpot.com/'})
     ],
     [
       '<link href="https://evertpot.com/" rel="me" title="my website!"/>',
-      new Link({rel: 'me', baseHref: '/index.html', href: 'https://evertpot.com/'})
+      new Link({rel: 'me', context: '/index.html', href: 'https://evertpot.com/'})
     ],
     [
       '<link href="foo.css" rel="stylesheet" type="text/css" />',
-      new Link({rel: 'stylesheet', baseHref: '/index.html', href: 'foo.css', type: 'text/css'})
+      new Link({rel: 'stylesheet', context: '/index.html', href: 'foo.css', type: 'text/css'})
     ],
     [
       '<a href="https://evertpot.com/" rel="me">',
-      new Link({rel: 'me', baseHref: '/index.html', href: 'https://evertpot.com/'})
+      new Link({rel: 'me', context: '/index.html', href: 'https://evertpot.com/'})
     ],
     [
       '<A href="https://evertpot.com/" rel="me">',
-      new Link({rel: 'me', baseHref: '/index.html', href: 'https://evertpot.com/'})
+      new Link({rel: 'me', context: '/index.html', href: 'https://evertpot.com/'})
     ],
     [
       '<a HREF="https://evertpot.com/" rel="me">',
-      new Link({rel: 'me', baseHref: '/index.html', href: 'https://evertpot.com/'})
+      new Link({rel: 'me', context: '/index.html', href: 'https://evertpot.com/'})
     ],
     [
       '<a rel="me" href="https://evertpot.com/">',
-      new Link({rel: 'me', baseHref: '/index.html', href: 'https://evertpot.com/'})
+      new Link({rel: 'me', context: '/index.html', href: 'https://evertpot.com/'})
     ],
     [
       '<a rel="icon favicon" href="favicon.ico">',
-      new Link({rel: 'icon', baseHref: '/index.html', href: 'favicon.ico'}),
-      new Link({rel: 'favicon', baseHref: '/index.html', href: 'favicon.ico'}),
+      new Link({rel: 'icon', context: '/index.html', href: 'favicon.ico'}),
+      new Link({rel: 'favicon', context: '/index.html', href: 'favicon.ico'}),
     ],
     [
       // Ignoring links without rel

--- a/test/unit/representor/jsonapi.ts
+++ b/test/unit/representor/jsonapi.ts
@@ -24,7 +24,7 @@ describe('JsonApi representor', () => {
     expect(r.contentType).to.equal('application/vnd.api+json');
     expect(r.links).to.eql([
       new Link({
-        baseHref: '/foo.json',
+        context: '/foo.json',
         href: 'https://example.org',
         rel: 'example',
       })
@@ -46,12 +46,12 @@ describe('JsonApi representor', () => {
     expect(r.contentType).to.equal('application/vnd.api+json');
     expect(r.links).to.eql([
       new Link({
-        baseHref: '/foo.json',
+        context: '/foo.json',
         href: 'https://example.org',
         rel: 'example',
       }),
       new Link({
-        baseHref: '/foo.json',
+        context: '/foo.json',
         href: 'https://example.com',
         rel: 'example',
       })
@@ -72,7 +72,7 @@ describe('JsonApi representor', () => {
     expect(r.contentType).to.equal('application/vnd.api+json');
     expect(r.links).to.eql([
       new Link({
-        baseHref: '/foo.json',
+        context: '/foo.json',
         href: 'https://example.org',
         rel: 'example',
       })
@@ -94,12 +94,12 @@ describe('JsonApi representor', () => {
     expect(r.contentType).to.equal('application/vnd.api+json');
     expect(r.links).to.eql([
       new Link({
-        baseHref: '/foo.json',
+        context: '/foo.json',
         href: 'https://example.org',
         rel: 'example',
       }),
       new Link({
-        baseHref: '/foo.json',
+        context: '/foo.json',
         href: 'https://example.com',
         rel: 'example',
       })


### PR DESCRIPTION
The name 'context' is used in the Web Linking RFC:

https://tools.ietf.org/html/rfc8288#section-3.2

Since we're doing a major release, this is a good time to clean this up. This is a minor BC break.

Fixes #122 