### PR TITLE
A simple prefer-push implementation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,17 @@
 ChangeLog
 =========
 
+3.1.0 (2019-03-27)
+------------------
+
+* If Ketting anticipates that a user might want to fetch multiple resources
+  in sequence (a follow chain), it will now add `Prefer-Push` header and
+  a `Prefer: transclude` header. Both are experimental internet drafts to
+  suggest to a server to do a HTTP/2 push or embed a child resource
+  respecitvely. This feature is experimental and might change as these drafts
+  change.
+
+
 3.0.2 (2019-03-19)
 ------------------
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketting",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Opiniated HATEAOS / Rest client.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -186,18 +186,15 @@ export default class Resource<T = any> {
     // will coalesc them into one.
     if (!this.inFlightRefresh) {
 
-      console.log('Want representation for %s', this.uri);
-
       const headers: { [name: string]: string } = {
         Accept: this.contentType ? this.contentType : this.client.getAcceptHeader()
       };
 
       if (this.preferPushRels.size > 0) {
         headers['Prefer-Push'] = Array.from(this.preferPushRels).join(' ');
-        headers['Prefer'] = 'transclude="' + Array.from(this.preferPushRels).join(';') + '"';
+        headers.Prefer = 'transclude="' + Array.from(this.preferPushRels).join(';') + '"';
       }
 
-      console.log(headers);
       this.inFlightRefresh = this.fetchAndThrow({
         method: 'GET' ,
         headers

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -55,12 +55,18 @@ export default class Resource<T = any> {
 
   private inFlightRefresh: Promise<any> = null;
 
+  /**
+   * A list of rels that should be added to a Prefer-Push header.
+   */
+  private preferPushRels: Set<string>;
+
   constructor(client: Ketting, uri: string, contentType: string = null) {
 
     this.client = client;
     this.uri = uri;
     this.repr = null;
     this.contentType = contentType;
+    this.preferPushRels = new Set();
 
   }
 
@@ -180,11 +186,21 @@ export default class Resource<T = any> {
     // will coalesc them into one.
     if (!this.inFlightRefresh) {
 
+      console.log('Want representation for %s', this.uri);
+
+      const headers: { [name: string]: string } = {
+        Accept: this.contentType ? this.contentType : this.client.getAcceptHeader()
+      };
+
+      if (this.preferPushRels.size > 0) {
+        headers['Prefer-Push'] = Array.from(this.preferPushRels).join(' ');
+        headers['Prefer'] = 'transclude="' + Array.from(this.preferPushRels).join(';') + '"';
+      }
+
+      console.log(headers);
       this.inFlightRefresh = this.fetchAndThrow({
         method: 'GET' ,
-        headers: {
-          Accept: this.contentType ? this.contentType : this.client.getAcceptHeader()
-        }
+        headers
       }).then( result1 => {
         response = result1;
         return response.text();
@@ -264,6 +280,10 @@ export default class Resource<T = any> {
 
     const r = await this.representation();
 
+    // After we got a representation, it no longer makes sense to remember
+    // the rels we want to add to Prefer-Push.
+    this.preferPushRels = new Set();
+
     if (!rel) { return r.links; }
 
     return r.links.filter( item => item.rel === rel );
@@ -278,6 +298,8 @@ export default class Resource<T = any> {
    * variables in the optional variables argument.
    */
   follow(rel: string, variables?: object): FollowablePromise {
+
+    this.preferPushRels.add(rel);
 
     return new FollowablePromise(async (res: any, rej: any) => {
 
@@ -317,6 +339,7 @@ export default class Resource<T = any> {
    */
   async followAll(rel: string): Promise<Resource[]> {
 
+    this.preferPushRels.add(rel);
     const links = await this.links(rel);
 
     return links.map((link: Link) => {

--- a/test/fixtures/hal-collection.json
+++ b/test/fixtures/hal-collection.json
@@ -29,7 +29,8 @@
                   "templated": true
                 }
               ],
-              "content-type-link" : { "href" : "/hal2.json", "type": "application/foo+json" }
+              "content-type-link" : { "href" : "/hal2.json", "type": "application/foo+json" },
+              "counter" : { "href" : "/counter" }
             },
             "title"  : "Hal 1",
             "foo" : "bar"

--- a/test/fixtures/hal1.json
+++ b/test/fixtures/hal1.json
@@ -23,7 +23,8 @@
           }
         ],
         "content-type-link" : { "href" : "/hal2.json", "type": "application/foo+json" },
-        "json-api" : { "href" : "/json-api.json", "type": "application/vnd.api+json" }
+        "json-api" : { "href" : "/json-api.json", "type": "application/vnd.api+json" },
+        "counter" : { "href" : "/counter" }
     },
     "title"  : "Hal 1",
     "foo" : "bar"

--- a/test/integration/get.ts
+++ b/test/integration/get.ts
@@ -86,4 +86,17 @@ describe('Issuing a GET request', async () => {
     expect(hadException).to.eql(true);
 
   });
+
+  it('should successfully de-duplicate multiple parallel refreshes', async() => {
+
+    const counterResource = await ketting.follow('counter');
+    const [result1, result2] = await Promise.all([
+      counterResource.refresh(),
+      counterResource.refresh()
+    ]);
+
+    expect(result1).to.be.eql(result2);
+
+  });
+
 });

--- a/test/testserver.ts
+++ b/test/testserver.ts
@@ -215,6 +215,17 @@ app.use(
     })
 );
 
+let counter = 0;
+// This endpoint returns a new number every time it gets called
+app.use(route('/counter').get( (ctx: Context) => {
+
+  counter++;
+  ctx.response.body = {
+    counter: counter,
+  };
+
+}));
+
 // Rest stuff!
 app.use(
   route('/:id')


### PR DESCRIPTION
This is a first stab at automatically adding:

* [Prefer-Push](https://tools.ietf.org/html/draft-pot-prefer-push)
* [Prefer: transclude](https://github.com/inadarei/draft-prefer-transclude/blob/master/draft-inadarei-prefer-transclude-00.txt)

Both of these drafts solve similar problems. This is gonna be added to the main Ketting library as an experimental feature, to hopefully get some early feedback. This should not impact most users as servers are unlikely to use it right now.