### PR TITLE
Rewrite of the representator system.

### DIFF
--- a/src/ketting.ts
+++ b/src/ketting.ts
@@ -8,6 +8,7 @@ import { ContentType, KettingInit } from './types';
 import FetchHelper from './utils/fetch-helper';
 import './utils/fetch-polyfill';
 import { resolve } from './utils/url';
+import { LinkSet } from './link';
 
 /**
  * The main Ketting client object.
@@ -133,13 +134,7 @@ export default class Ketting {
 
   }
 
-  /**
-   * This function returns a representor constructor for a mime type.
-   *
-   * For example, given text/html, this function might return the constructor
-   * stored in representor/html.
-   */
-  getRepresentor(contentType: string): typeof Representor {
+  createRepresentation(uri: string, contentType: string, body: string | null, headerLinks: LinkSet): Representor<any> {
 
     if (contentType.indexOf(';') !== -1) {
       contentType = contentType.split(';')[0];
@@ -154,19 +149,18 @@ export default class Ketting {
     }
 
     switch (result.representor) {
-    case 'html' :
-        return HtmlRepresentor;
+      case 'html' :
+        return new HtmlRepresentor(uri, contentType, body, headerLinks);
     case 'hal' :
-        return HalRepresentor;
+        return new HalRepresentor(uri, contentType, body, headerLinks);
     case 'jsonapi' :
-        return JsonApiRepresentor;
+        return new JsonApiRepresentor(uri, contentType, body, headerLinks);
     default :
       throw new Error('Unknown representor: ' + result.representor);
 
     }
 
   }
-
 
   /**
    * Generates an accept header string, based on registered Resource Types.

--- a/src/ketting.ts
+++ b/src/ketting.ts
@@ -1,4 +1,5 @@
 import FollowablePromise from './followable-promise';
+import { LinkSet } from './link';
 import Representor from './representor/base';
 import HalRepresentor from './representor/hal';
 import HtmlRepresentor from './representor/html';
@@ -8,7 +9,6 @@ import { ContentType, KettingInit } from './types';
 import FetchHelper from './utils/fetch-helper';
 import './utils/fetch-polyfill';
 import { resolve } from './utils/url';
-import { LinkSet } from './link';
 
 /**
  * The main Ketting client object.

--- a/src/ketting.ts
+++ b/src/ketting.ts
@@ -39,7 +39,7 @@ export default class Ketting {
    */
   private fetchHelper: FetchHelper;
 
-  constructor(bookMark: string, options?: KettingInit) {
+  constructor(bookMark: string, options?: Partial<KettingInit>) {
 
     if (typeof options === 'undefined') {
       options = {};

--- a/src/link.ts
+++ b/src/link.ts
@@ -101,4 +101,4 @@ export default Link;
 
 export type LinkSet = Map<string, Link[]>;
 
-export class LinkNotFound extends Error {};
+export class LinkNotFound extends Error {}

--- a/src/link.ts
+++ b/src/link.ts
@@ -14,7 +14,7 @@ type LinkInit = {
 /**
  * The Link object represents a hyperlink.
  */
-export default class Link {
+export class Link {
 
   /**
    * The base href of the parent document. Used for expanding relative links.
@@ -96,3 +96,9 @@ export default class Link {
   }
 
 }
+
+export default Link;
+
+export type LinkSet = Map<string, Link[]>;
+
+export class LinkNotFound extends Error {};

--- a/src/link.ts
+++ b/src/link.ts
@@ -99,6 +99,13 @@ export class Link {
 
 export default Link;
 
+/**
+ * A LinkSet is just a map of links, indexes by their rel
+ */
 export type LinkSet = Map<string, Link[]>;
 
+/**
+ * The LinkNotFound error gets thrown whenever something tries to follow a
+ * link by its rel, that doesn't exist
+ */
 export class LinkNotFound extends Error {}

--- a/src/representor/base.ts
+++ b/src/representor/base.ts
@@ -21,7 +21,7 @@ export default abstract class Representation<T = string> {
     this.contentType = contentType;
     this.links = headerLinks;
     if (body !== null) {
-      this.body = this.parse(body);
+      this.setBody(this.parse(body));
     }
 
   }
@@ -31,7 +31,7 @@ export default abstract class Representation<T = string> {
     const links = this.links.get(rel);
 
     if (!links) {
-      throw new LinkNotFound('Link with rel: ' + rel + ' not found');
+      throw new LinkNotFound('Link with rel: ' + rel + ' not found on resource: ' + this.uri);
     }
 
     return links[0];
@@ -76,6 +76,7 @@ export default abstract class Representation<T = string> {
         this.links.set(link.rel, [link]);
       }
     }
+    this.body = body;
   }
 
   /**

--- a/src/representor/base.ts
+++ b/src/representor/base.ts
@@ -1,4 +1,4 @@
-import { Link, LinkSet, LinkNotFound } from '../link';
+import { Link, LinkNotFound, LinkSet } from '../link';
 
 
 /**
@@ -68,7 +68,7 @@ export default abstract class Representation<T = string> {
   }
 
   setBody(body: T) {
-    for(const link of this.parseLinks(body)) {
+    for (const link of this.parseLinks(body)) {
       if (this.links.has(link.rel)) {
         this.links.get(link.rel).push(link);
       } else {
@@ -84,7 +84,7 @@ export default abstract class Representation<T = string> {
    * For JSON responses, usually this means calling JSON.parse() and returning
    * the result.
    */
-  protected abstract parse(body: string): T; 
+  protected abstract parse(body: string): T;
 
   /**
    * Parse links.

--- a/src/representor/base.ts
+++ b/src/representor/base.ts
@@ -28,11 +28,12 @@ export default abstract class Representation<T = string> {
 
   getLink(rel: string): Link {
 
-    if (!this.links.has(rel)) {
+    const links = this.links.get(rel);
+
+    if (!links) {
       throw new LinkNotFound('Link with rel: ' + rel + ' not found');
     }
 
-    const links = this.links.get(rel);
     return links[0];
 
   }
@@ -40,7 +41,7 @@ export default abstract class Representation<T = string> {
   getLinks(rel?: string): Link[] {
 
     if (!rel) {
-      return [].concat(...this.links.values());
+      return ([] as Link[]).concat(...this.links.values());
     }
 
     const links = this.links.get(rel);
@@ -70,7 +71,7 @@ export default abstract class Representation<T = string> {
   setBody(body: T) {
     for (const link of this.parseLinks(body)) {
       if (this.links.has(link.rel)) {
-        this.links.get(link.rel).push(link);
+        this.links.get(link.rel)!.push(link);
       } else {
         this.links.set(link.rel, [link]);
       }

--- a/src/representor/hal.ts
+++ b/src/representor/hal.ts
@@ -70,6 +70,7 @@ export default class Hal extends Representation<HalBody> {
 
     const newBody = Object.assign({}, this.body);
     delete newBody._embedded;
+    delete newBody._links;
 
     return newBody;
 

--- a/src/representor/hal.ts
+++ b/src/representor/hal.ts
@@ -2,57 +2,6 @@ import Link from '../link';
 import { resolve } from '../utils/url';
 import Representation from './base';
 
-/**
- * The Representation class is basically a 'body' of a request
- * or response.
- *
- * This class is for HAL JSON responses.
- */
-export default class Hal extends Representation {
-
-  body: { [s: string]: any };
-
-  constructor(uri: string, contentType: string, body: any) {
-
-    super(uri, contentType, body);
-
-    if (typeof body === 'string') {
-      this.body = JSON.parse(body);
-    } else {
-      this.body = body;
-    }
-
-    if (typeof this.body._links !== 'undefined') {
-      parseHalLinks(this);
-    }
-    if (typeof this.body._embedded !== 'undefined') {
-      parseHalEmbedded(this);
-    }
-
-    delete this.body._links;
-    delete this.body._embedded;
-
-  }
-
-}
-
-/**
- * Parse the Hal _links object and populate the 'links' property.
- */
-const parseHalLinks = (representation: Hal): void => {
-
-  for (const relType of Object.keys((<any> representation.body)._links)) {
-
-    let links = (<any> representation.body)._links[relType];
-    if (!Array.isArray(links)) {
-      links = [links];
-    }
-    parseHalLink(representation, relType, links);
-
-  }
-
-};
-
 type HalLink = {
   href: string,
   name?: string,
@@ -61,16 +10,132 @@ type HalLink = {
   type?: string
 };
 
+type HalBody = {
+  _links?: {
+    [rel: string]: HalLink | HalLink[],
+  }
+  [key: string]: any,
+  _embedded?: {
+    [rel: string]: HalBody | HalBody[],
+  }
+}
+
+/**
+ * Internal representation for embedded resources
+ */
+type Embedded = {
+  href: string,
+  contextUri: string,
+  rel: string,
+  body: HalBody
+};
+
+/**
+ * The Representation class is basically a 'body' of a request
+ * or response.
+ *
+ * This class is for HAL JSON responses.
+ */
+export default class Hal extends Representation<HalBody> {
+
+  embedded: Embedded[];
+
+  /**
+   * parse is called to convert a HTTP response body string into the most
+   * suitable internal body type.
+   *
+   * For JSON responses, usually this means calling JSON.parse() and returning
+   * the result.
+   */
+  parse(body: string): HalBody {
+
+    return JSON.parse(body);
+
+  }
+
+  parseLinks(body: HalBody): Link[] {
+
+    return parseHalLinks(this.uri, body);
+
+  }
+
+  /**
+   * Returns the parsed body for this representation.
+   *
+   * Specific implementations of this class might alter the response before
+   * returning, for example to remove meta-information that's not relevant
+   * the user of this object.
+   */
+  getBody(): HalBody {
+
+    const newBody = Object.assign({}, this.body);
+    delete newBody._embedded;
+
+    return newBody;
+
+  }
+
+  getEmbedded(): { [uri: string]: HalBody } {
+
+    const result: { [uri:string]: HalBody } = {};
+    for(const embedded of parseHalEmbedded(this.uri, this.body)) {
+      result[resolve(this.uri, embedded.href)] = embedded.body;
+    }
+    return result;
+
+  }
+}
+
+/**
+ * Parse the Hal _links object and populate the 'links' property.
+ */
+function parseHalLinks(contextUri: string, body: HalBody): Link[] {
+
+  if (body._links === undefined) {
+    return [];
+  }
+
+  const result: Link[] = [];
+
+  for (const [relType, links] of Object.entries(body._links)) {
+
+    const linkList = Array.isArray(links) ? links : [links];
+    
+    result.push(
+      ...parseHalLink(contextUri, relType, linkList)
+    );
+
+  }
+  
+  const embedded = parseHalEmbedded(contextUri, body);
+
+  for(const embeddedItem of embedded) {
+
+    result.push(new Link({
+      rel: embeddedItem.rel,
+      href: embeddedItem.href,
+      context: embeddedItem.contextUri,
+    }));
+
+  }
+
+  return result;
+
+};
+
+
 /**
  * Parses a single HAL link from a _links object, or a list of links.
  */
-const parseHalLink = (representation: Hal, rel: string, links: HalLink[]): void => {
+function parseHalLink(contextUri: string, rel: string, links: HalLink[]): Link[] {
+
+  const result: Link[] = [];
 
   for (const link of links) {
-    representation.links.push(
+    result.push(
       new Link({
         rel: rel,
-        context: representation.uri,
+        context: contextUri,
         href: link.href,
         title: link.title,
         type: link.type,
@@ -80,42 +145,48 @@ const parseHalLink = (representation: Hal, rel: string, links: HalLink[]): void 
     );
   }
 
-};
+  return result;
+
+}
 
 /**
  * Parse the HAL _embedded object. Right now we're just grabbing the
  * information from _embedded and turn it into links.
  */
-const parseHalEmbedded = (representation: Hal): void => {
+function parseHalEmbedded(contextUri: string, body: HalBody): Embedded[] {
 
-  for (const relType of Object.keys((<any> representation).body._embedded)) {
+  if (body._embedded === undefined) {
+    return [];
+  }
 
-    let embedded = (<any> representation).body._embedded[relType];
+  const result: Embedded[] = [];
+
+  for(const [rel, embedded] of Object.entries(body._embedded)) {
+
+    let embeddedList: HalBody[] = [];
+
     if (!Array.isArray(embedded)) {
-      embedded = [embedded];
+      embeddedList = [embedded];
+    } else {
+      embeddedList = embedded;
+
     }
-    for (const embeddedItem of embedded) {
+    for (const embeddedItem of embeddedList) {
 
-      const uri = resolve(
-        representation.uri,
-        embeddedItem._links.self.href
-      );
-
-      // Only adding a link to the representation if it didn't already exist.
-      if (!representation.links.find( item => {
-        return item.rel === relType && embeddedItem._links.self.href === item.href;
-      })) {
-        representation.links.push(
-          new Link({
-            rel: relType,
-            context: representation.uri,
-            href: embeddedItem._links.self.href
-          })
-        );
+      if (embeddedItem._links === undefined || embeddedItem._links.self === undefined || Array.isArray(embeddedItem._links.self)) {
+        // Skip any embedded without a self link.
+        continue;
       }
 
-      representation.embedded[uri] = embeddedItem;
-
+      result.push({
+        rel,
+        contextUri,
+        href: embeddedItem._links.self.href,
+        body: embeddedItem
+      });
     }
   }
-};
+
+  return result;
+
+}

--- a/src/representor/hal.ts
+++ b/src/representor/hal.ts
@@ -18,7 +18,7 @@ type HalBody = {
   _embedded?: {
     [rel: string]: HalBody | HalBody[],
   }
-}
+};
 
 /**
  * Internal representation for embedded resources
@@ -77,8 +77,8 @@ export default class Hal extends Representation<HalBody> {
 
   getEmbedded(): { [uri: string]: HalBody } {
 
-    const result: { [uri:string]: HalBody } = {};
-    for(const embedded of parseHalEmbedded(this.uri, this.body)) {
+    const result: { [uri: string]: HalBody } = {};
+    for (const embedded of parseHalEmbedded(this.uri, this.body)) {
       result[resolve(this.uri, embedded.href)] = embedded.body;
     }
     return result;
@@ -100,16 +100,16 @@ function parseHalLinks(contextUri: string, body: HalBody): Link[] {
   for (const [relType, links] of Object.entries(body._links)) {
 
     const linkList = Array.isArray(links) ? links : [links];
-    
+
     result.push(
       ...parseHalLink(contextUri, relType, linkList)
     );
 
   }
-  
+
   const embedded = parseHalEmbedded(contextUri, body);
 
-  for(const embeddedItem of embedded) {
+  for (const embeddedItem of embedded) {
 
     result.push(new Link({
       rel: embeddedItem.rel,
@@ -121,7 +121,7 @@ function parseHalLinks(contextUri: string, body: HalBody): Link[] {
 
   return result;
 
-};
+}
 
 
 /**
@@ -161,7 +161,7 @@ function parseHalEmbedded(contextUri: string, body: HalBody): Embedded[] {
 
   const result: Embedded[] = [];
 
-  for(const [rel, embedded] of Object.entries(body._embedded)) {
+  for (const [rel, embedded] of Object.entries(body._embedded)) {
 
     let embeddedList: HalBody[] = [];
 

--- a/src/representor/html.ts
+++ b/src/representor/html.ts
@@ -9,13 +9,18 @@ import Representation from './base';
  * This class is for HTML responses. The html.web.js version is the version
  * intended for browsers. The regular html.js is intended for node.js.
  */
-export default class Html extends Representation {
+export default class Html extends Representation<string> {
 
-  constructor(uri: string, contentType: string, body: string) {
-
-    super(uri, contentType, body);
+  /**
+   * Parse links.
+   *
+   * This function gets called once by this object to parse any in-document
+   * links.
+   */
+  protected parseLinks(body: string): Link[] {
 
     const parser = sax.parser(false, {});
+    const links: Link[] = [];
 
     parser.onopentag = node => {
 
@@ -36,7 +41,7 @@ export default class Html extends Representation {
           href: <string> node.attributes.HREF,
           type: <string> node.attributes.TYPE || undefined
         });
-        this.links.push(link);
+        links.push(link);
 
       }
 
@@ -44,6 +49,20 @@ export default class Html extends Representation {
 
     parser.write(body).close();
 
+    return links;
+
   }
 
+  /**
+   * parse is called to convert a HTTP response body string into the most
+   * suitable internal body type.
+   *
+   * For HTML, we are keeping the response as a string instead of returning
+   * for example a DOM.
+   */
+  protected parse(body: string): string {
+
+    return body;
+
+  }
 }

--- a/src/representor/html.web.ts
+++ b/src/representor/html.web.ts
@@ -52,7 +52,7 @@ export default class Html extends Representation<string> {
 
 function linkFromTags(contextUri: string, elements: HTMLCollectionOf<HTMLElement>): Link[] {
 
-  const result:Link[] = [];
+  const result: Link[] = [];
 
   for (const node of elements) {
 

--- a/src/representor/html.web.ts
+++ b/src/representor/html.web.ts
@@ -8,30 +8,51 @@ import Representation from './base';
  * This class is for HTML responses. The html.web.js version is the version
  * intended for browsers. The regular html.js is intended for node.js.
  */
-export default class Html extends Representation {
+export default class Html extends Representation<string> {
 
-  constructor(uri: string, contentType: string, body: string) {
-
-    super(uri, contentType, body);
+  /**
+   * Parse links.
+   *
+   * This function gets called once by this object to parse any in-document
+   * links.
+   */
+  protected parseLinks(body: string): Link[] {
 
     const parser = new DOMParser();
     const doc = parser.parseFromString(body, 'text/html');
 
     linkFromTags(
-      this,
+      this.uri,
       doc.getElementsByTagName('link')
     );
 
     linkFromTags(
-      this,
+      this.uri,
       doc.getElementsByTagName('a')
     );
+
+    return [];
+
+  }
+
+  /**
+   * parse is called to convert a HTTP response body string into the most
+   * suitable internal body type.
+   *
+   * For HTML, we are keeping the response as a string instead of returning
+   * for example a DOM.
+   */
+  protected parse(body: string): string {
+
+    return body;
 
   }
 
 }
 
-function linkFromTags(htmlDoc: Html, elements: HTMLCollectionOf<HTMLElement>) {
+function linkFromTags(contextUri: string, elements: HTMLCollectionOf<HTMLElement>): Link[] {
+
+  const result:Link[] = [];
 
   for (const node of elements) {
 
@@ -47,14 +68,15 @@ function linkFromTags(htmlDoc: Html, elements: HTMLCollectionOf<HTMLElement>) {
 
       const link = new Link({
         rel: rel,
-        context: htmlDoc.uri,
+        context: contextUri,
         href: href,
         type: type
       });
-      htmlDoc.links.push(link);
+      result.push(link);
 
     }
 
   }
+  return result;
 
 }

--- a/src/representor/jsonapi.ts
+++ b/src/representor/jsonapi.ts
@@ -57,7 +57,7 @@ export default class JsonApi extends Representation<JsonApiTopLevelObject> {
   protected parseLinks(body: any): Link[] {
 
     return ([] as Link[]).concat(
-      parseJsonApiLinks(this.uri, this.body),
+      parseJsonApiLinks(this.uri, body),
       parseJsonApiCollection(this.uri, body)
     );
 

--- a/src/representor/jsonapi.ts
+++ b/src/representor/jsonapi.ts
@@ -14,8 +14,8 @@ type JsonApiLink = string | { href: string };
  */
 type JsonApiLinksObject = {
   self?: JsonApiLink,
-  profile?: JsonApiLink
-  [rel: string]: JsonApiLink | JsonApiLink[]
+  profile?: JsonApiLink,
+  [rel: string]: JsonApiLink | JsonApiLink[] | undefined
 };
 
 /**
@@ -56,7 +56,7 @@ export default class JsonApi extends Representation<JsonApiTopLevelObject> {
    */
   protected parseLinks(body: any): Link[] {
 
-    return [].concat(
+    return ([] as Link[]).concat(
       parseJsonApiLinks(this.uri, this.body),
       parseJsonApiCollection(this.uri, body)
     );
@@ -94,7 +94,7 @@ function parseJsonApiLinks(baseHref: string, body: JsonApiTopLevelObject): Link[
     if (Array.isArray(linkValue)) {
       result.push(...linkValue.map( link => parseJsonApiLink(baseHref, rel, link)));
     } else {
-      result.push(parseJsonApiLink(baseHref, rel, linkValue));
+      result.push(parseJsonApiLink(baseHref, rel, linkValue!));
     }
 
   }
@@ -121,9 +121,9 @@ function parseJsonApiCollection(baseHref: string, body: JsonApiTopLevelObject): 
   const result: Link[] = [];
   for (const member of body.data) {
 
-    if ('self' in member.links) {
+    if ('links' in member && 'self' in member.links!) {
 
-      const selfLink = parseJsonApiLink(baseHref, 'self', member.links.self);
+      const selfLink = parseJsonApiLink(baseHref, 'self', member.links!.self!);
       result.push(new Link({
         context: baseHref,
         href: selfLink.href,

--- a/src/representor/jsonapi.ts
+++ b/src/representor/jsonapi.ts
@@ -46,24 +46,33 @@ type JsonApiTopLevelObject = {
  * The Representor is responsible from extracting any links from the body,
  * so they can be followed.
  */
-export default class JsonApi extends Representation {
+export default class JsonApi extends Representation<JsonApiTopLevelObject> {
 
-  body: JsonApiTopLevelObject;
+  /**
+   * Parse links.
+   *
+   * This function gets called once by this object to parse any in-document
+   * links.
+   */
+  protected parseLinks(body: any): Link[] {
 
-  constructor(uri: string, contentType: string, body: any) {
+    return [].concat(
+      parseJsonApiLinks(this.uri, this.body),
+      parseJsonApiCollection(this.uri, body)
+    );
 
-    super(uri, contentType, body);
+  }
 
-    if (typeof body === 'string') {
-      this.body = JSON.parse(body);
-    } else {
-      this.body = body;
-    }
+  /**
+   * parse is called to convert a HTTP response body string into the most
+   * suitable internal body type.
+   *
+   * For JSON responses, usually this means calling JSON.parse() and returning
+   * the result.
+   */
+  protected parse(body: string): JsonApiTopLevelObject {
 
-    this.links = [
-      ...parseJsonApiLinks(uri, this.body),
-      ...parseJsonApiCollection(uri, this.body)
-    ];
+    return JSON.parse(body);
 
   }
 

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -217,7 +217,7 @@ export default class Resource<T = any> {
 
     // Extracting HTTP Link header.
     const httpLinkHeader = response.headers.get('Link');
-    
+
     const headerLinks: LinkSet = new Map();
 
     if (httpLinkHeader) {
@@ -252,7 +252,7 @@ export default class Resource<T = any> {
       this.contentType = contentType;
     }
 
-    for(const [subUri, subBody] of Object.entries(this.repr.getEmbedded())) {
+    for (const [subUri, subBody] of Object.entries(this.repr.getEmbedded())) {
       const subResource = this.go(subUri);
       subResource.repr = this.client.createRepresentation(
         subUri,
@@ -260,7 +260,7 @@ export default class Resource<T = any> {
         null,
         new Map(),
       );
-      subResource.repr.setBody(subBody)
+      subResource.repr.setBody(subBody);
     }
 
     return this.repr.getBody();

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -2,7 +2,7 @@ import * as LinkHeader from 'http-link-header';
 import FollowablePromise from './followable-promise';
 import problemFactory from './http-error';
 import Ketting from './ketting';
-import Link from './link';
+import { Link, LinkSet } from './link';
 import Representation from './representor/base';
 import { mergeHeaders } from './utils/fetch-helper';
 import { resolve } from './utils/url';
@@ -30,7 +30,7 @@ export default class Resource<T = any> {
   /**
    * The current representation, or body of the resource.
    */
-  repr: Representation | null;
+  repr: Representation<T> | null;
 
   /**
    * The uri of the resource
@@ -77,7 +77,7 @@ export default class Resource<T = any> {
   async get(): Promise<T> {
 
     const r = await this.representation();
-    return r.body;
+    return r.getBody();
 
   }
 
@@ -214,47 +214,56 @@ export default class Resource<T = any> {
     if (!contentType) {
       throw new Error('Server did not respond with a Content-Type header');
     }
-    this.repr = new (this.client.getRepresentor(contentType))(
-       this.uri,
-       contentType,
-       body
-    );
+
+    // Extracting HTTP Link header.
+    const httpLinkHeader = response.headers.get('Link');
+    
+    const headerLinks: LinkSet = new Map();
+
+    if (httpLinkHeader) {
+
+      for (const httpLink of LinkHeader.parse(httpLinkHeader).refs) {
+        // Looping through individual links
+        for (const rel of httpLink.rel.split(' ')) {
+          // Looping through space separated rel values.
+          if (headerLinks.has(rel)) {
+            const newLink = new Link({
+              rel: rel,
+              context: this.uri,
+              href: httpLink.uri
+            });
+            if (headerLinks.has(rel)) {
+              headerLinks.get(rel).push(newLink);
+            } else {
+              headerLinks.set(rel, [newLink]);
+            }
+          }
+        }
+      }
+    }
+    this.repr = this.client.createRepresentation(
+      this.uri,
+      contentType,
+      body,
+      headerLinks
+    ) as any as Representation<T>;
 
     if (!this.contentType) {
       this.contentType = contentType;
     }
 
-    // Extracting HTTP Link header.
-    const httpLinkHeader = response.headers.get('Link');
-    if (httpLinkHeader) {
-
-      for (const httpLink of LinkHeader.parse(httpLinkHeader).refs) {
-        // Looping through individual links
-         for (const rel of httpLink.rel.split(' ')) {
-           // Looping through space separated rel values.
-           this.repr.links.push(
-              new Link({
-                rel: rel,
-                context: this.uri,
-                href: httpLink.uri
-              })
-           );
-         }
-      }
-
-    }
-
-    // Parsing and storing embedded uris
-    for (const uri of Object.keys(this.repr.embedded)) {
-      const subResource = this.go(uri);
-      subResource.repr = new (this.client.getRepresentor(contentType))(
-        uri,
+    for(const [subUri, subBody] of Object.entries(this.repr.getEmbedded())) {
+      const subResource = this.go(subUri);
+      subResource.repr = this.client.createRepresentation(
+        subUri,
         contentType,
-        this.repr.embedded[uri]
+        null,
+        new Map(),
       );
+      subResource.repr.setBody(subBody)
     }
 
-    return this.repr.body;
+    return this.repr.getBody();
 
   }
 
@@ -272,9 +281,7 @@ export default class Resource<T = any> {
     // the rels we want to add to Prefer-Push.
     this.preferPushRels = new Set();
 
-    if (!rel) { return r.links; }
-
-    return r.links.filter( item => item.rel === rel );
+    return r.getLinks(rel);
 
   }
 
@@ -292,21 +299,19 @@ export default class Resource<T = any> {
     return new FollowablePromise(async (res: any, rej: any) => {
 
       try {
-        const links = await this.links(rel);
+        const link = await this.repr.getLink(rel);
 
         let href;
-        if (links.length === 0) {
-          throw new Error('Relation with type ' + rel + ' not found on resource ' + this.uri);
-        }
-        if (links[0].templated && variables) {
-          href = links[0].expand(variables);
+
+        if (link.templated && variables) {
+          href = link.expand(variables);
         } else {
-          href = links[0].resolve();
+          href = link.resolve();
         }
 
         const resource = this.go(href);
-        if (links[0].type) {
-          resource.contentType = links[0].type;
+        if (link.type) {
+          resource.contentType = link.type;
         }
 
         res(resource);
@@ -362,13 +367,13 @@ export default class Resource<T = any> {
    * Usually you will want to use the `get()` method instead, unless you need
    * the full object.
    */
-  async representation(): Promise<Representation> {
+  async representation(): Promise<Representation<T>> {
 
     if (!this.repr) {
       await this.refresh();
     }
 
-    return <Representation> this.repr;
+    return this.repr;
 
   }
 

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -226,17 +226,15 @@ export default class Resource<T = any> {
         // Looping through individual links
         for (const rel of httpLink.rel.split(' ')) {
           // Looping through space separated rel values.
+          const newLink = new Link({
+            rel: rel,
+            context: this.uri,
+            href: httpLink.uri
+          });
           if (headerLinks.has(rel)) {
-            const newLink = new Link({
-              rel: rel,
-              context: this.uri,
-              href: httpLink.uri
-            });
-            if (headerLinks.has(rel)) {
-              headerLinks.get(rel)!.push(newLink);
-            } else {
-              headerLinks.set(rel, [newLink]);
-            }
+            headerLinks.get(rel)!.push(newLink);
+          } else {
+            headerLinks.set(rel, [newLink]);
           }
         }
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ export type KettingInit = {
    * It's effectively a list of defaults that are passed as the 'init' argument.
    * @see https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
    */
-  fetchInit?: RequestInit,
+  fetchInit: RequestInit,
 
   /**
    * Per-domain options.
@@ -45,7 +45,7 @@ export type KettingInit = {
    * This setting allows you to override specific options on a per-domain
    * basis. It's possible to specify wildcards here.
    */
-  match?: {
+  match: {
     [domain: string]: {
       auth?: AuthOptions
       fetchInit?: RequestInit,

--- a/src/utils/fetch-helper.ts
+++ b/src/utils/fetch-helper.ts
@@ -30,7 +30,7 @@ export default class FetchHelper {
       fetchInit: options.fetchInit || {},
       auth: options.auth,
       match: options.match || {},
-    }
+    };
     this.oAuth2Buckets = new Map();
     this.innerFetch = fetch.bind(global);
     this.onBeforeRequest = onBeforeRequest;

--- a/test/unit/ketting.ts
+++ b/test/unit/ketting.ts
@@ -9,16 +9,16 @@ describe('Ketting', () => {
   it('should return a HTML representor when requested', () => {
 
     const ketting = new Ketting('https://example.org/');
-    const representor = ketting.createRepresentation('/foo', 'text/html', '', new Map());
-    expect(representor).to.eql(Html);
+    const representor = ketting.createRepresentation('/foo', 'text/html', null, new Map());
+    expect(representor).to.be.instanceof(Html);
 
   });
 
   it('should return a Hal representor when requested', () => {
 
     const ketting = new Ketting('https://example.org');
-    const representor = ketting.createRepresentation('/foo', 'application/hal+json', '', new Map());
-    expect(representor).to.eql(Hal);
+    const representor = ketting.createRepresentation('/foo', 'application/hal+json', null, new Map());
+    expect(representor).to.be.instanceof(Hal);
 
   });
 

--- a/test/unit/ketting.ts
+++ b/test/unit/ketting.ts
@@ -9,7 +9,7 @@ describe('Ketting', () => {
   it('should return a HTML representor when requested', () => {
 
     const ketting = new Ketting('https://example.org/');
-    const representor = ketting.getRepresentor('text/html');
+    const representor = ketting.createRepresentation('/foo', 'text/html', '', new Map());
     expect(representor).to.eql(Html);
 
   });
@@ -17,7 +17,7 @@ describe('Ketting', () => {
   it('should return a Hal representor when requested', () => {
 
     const ketting = new Ketting('https://example.org');
-    const representor = ketting.getRepresentor('application/hal+json');
+    const representor = ketting.createRepresentation('/foo', 'application/hal+json', '', new Map());
     expect(representor).to.eql(Hal);
 
   });
@@ -25,7 +25,7 @@ describe('Ketting', () => {
   it('should throw an error when an unknown representor was requested ', () => {
 
     const ketting = new Ketting('https://example.org');
-    expect( () => ketting.getRepresentor('text/plain') ).to.throw(Error);
+    expect( () => ketting.createRepresentation('/foo', 'text/plain', '', new Map())).to.throw(Error);
 
   });
 
@@ -36,7 +36,7 @@ describe('Ketting', () => {
       mime: 'text/plain',
       representor: 'bla-bla'
     });
-    expect( () => ketting.getRepresentor('text/plain') ).to.throw(Error);
+    expect( () => ketting.createRepresentation('/foo', 'text/plain', '', new Map()) ).to.throw(Error);
 
   });
 

--- a/test/unit/representor/html.ts
+++ b/test/unit/representor/html.ts
@@ -71,13 +71,13 @@ describe('HTML representor', () => {
 
     it('should parse ' + value[0], () => {
 
-      const html = new Html('/index.html', 'text/html', value[0]);
+      const html = new Html('/index.html', 'text/html', value[0], new Map());
 
       const links = value.slice(1);
 
       expect(html.uri).to.equal('/index.html');
       expect(html.contentType).to.equal('text/html');
-      expect(html.links).to.eql(links);
+      expect(html.getLinks()).to.eql(links);
 
     });
 

--- a/test/unit/representor/jsonapi.ts
+++ b/test/unit/representor/jsonapi.ts
@@ -6,10 +6,10 @@ describe('JsonApi representor', () => {
 
   it('should parse objects without links' , () => {
 
-    const r = new JsonApi('/foo.json', 'application/vnd.api+json', '{"foo": "bar"}');
+    const r = new JsonApi('/foo.json', 'application/vnd.api+json', '{"foo": "bar"}', new Map());
     expect(r.contentType).to.equal('application/vnd.api+json');
-    expect(r.body).to.eql({foo: 'bar'});
-    expect(r.links.length).to.equal(0);
+    expect(r.getBody()).to.eql({foo: 'bar'});
+    expect(r.getLinks().length).to.equal(0);
 
   });
 
@@ -18,11 +18,16 @@ describe('JsonApi representor', () => {
     const input = {
       links: {
         example: 'https://example.org',
-      }
+      },
+      data: {
+        type: 'foo',
+        id: 'bar',
+      },
     };
-    const r = new JsonApi('/foo.json', 'application/vnd.api+json', input);
+    const r = new JsonApi('/foo.json', 'application/vnd.api+json', null, new Map());
+    r.setBody(input);
     expect(r.contentType).to.equal('application/vnd.api+json');
-    expect(r.links).to.eql([
+    expect(r.getLinks()).to.eql([
       new Link({
         context: '/foo.json',
         href: 'https://example.org',
@@ -40,11 +45,16 @@ describe('JsonApi representor', () => {
           'https://example.org',
           'https://example.com',
         ]
-      }
+      },
+      data: {
+        type: 'foo',
+        id: 'bar',
+      },
     };
-    const r = new JsonApi('/foo.json', 'application/vnd.api+json', input);
+    const r = new JsonApi('/foo.json', 'application/vnd.api+json', null, new Map());
+    r.setBody(input);
     expect(r.contentType).to.equal('application/vnd.api+json');
-    expect(r.links).to.eql([
+    expect(r.getLinks()).to.eql([
       new Link({
         context: '/foo.json',
         href: 'https://example.org',
@@ -66,11 +76,16 @@ describe('JsonApi representor', () => {
         example: {
           href: 'https://example.org'
         },
-      }
+      },
+      data: {
+        type: 'foo',
+        id: 'bar',
+      },
     };
-    const r = new JsonApi('/foo.json', 'application/vnd.api+json', input);
+    const r = new JsonApi('/foo.json', 'application/vnd.api+json', null, new Map());
+    r.setBody(input);
     expect(r.contentType).to.equal('application/vnd.api+json');
-    expect(r.links).to.eql([
+    expect(r.getLinks()).to.eql([
       new Link({
         context: '/foo.json',
         href: 'https://example.org',
@@ -88,11 +103,16 @@ describe('JsonApi representor', () => {
           { href: 'https://example.org' },
           { href: 'https://example.com' },
         ]
-      }
+      },
+      data: {
+        type: 'foo',
+        id: 'bar',
+      },
     };
-    const r = new JsonApi('/foo.json', 'application/vnd.api+json', input);
+    const r = new JsonApi('/foo.json', 'application/vnd.api+json', null, new Map());
+    r.setBody(input);
     expect(r.contentType).to.equal('application/vnd.api+json');
-    expect(r.links).to.eql([
+    expect(r.getLinks()).to.eql([
       new Link({
         context: '/foo.json',
         href: 'https://example.org',

--- a/test/unit/utils/fetch-helper.ts
+++ b/test/unit/utils/fetch-helper.ts
@@ -39,16 +39,16 @@ describe('fetch-helper', () => {
     };
 
     await fh.fetch('http://example.net', {});
-    expect(lastRequest.headers.get('Authorization')).to.equal('Bearer keyA');
+    expect(lastRequest!.headers.get('Authorization')).to.equal('Bearer keyA');
 
     await fh.fetch('http://foo.example.org', {});
-    expect(lastRequest.headers.get('Authorization')).to.equal('Bearer keyB');
+    expect(lastRequest!.headers.get('Authorization')).to.equal('Bearer keyB');
 
     await fh.fetch('http://bar.example.org', {});
-    expect(lastRequest.headers.get('Authorization')).to.equal('Bearer keyA');
+    expect(lastRequest!.headers.get('Authorization')).to.equal('Bearer keyA');
 
     await fh.fetch('http://foo.example.com', {});
-    expect(lastRequest.headers.get('Authorization')).to.equal('Bearer keyC');
+    expect(lastRequest!.headers.get('Authorization')).to.equal('Bearer keyC');
   });
 
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
         "noImplicitAny": true,
 
         "strictFunctionTypes": true,
+        "strictNullChecks": true,
         "noImplicitThis": true,
         "alwaysStrict": true,
         "noUnusedLocals": true,


### PR DESCRIPTION
This PR makes support for new formats easier to add in, and opens the door to a few more features.

The representor system was probably among the oldest bits in ketting, and was from a time where I didn't understand typescript as well as I do now.

This also turns on typescript's `strictNullChecks`, which makes typing much stricter when it comes to initializing things with `undefined` or `null`.