### PR TITLE
Added a LOT more types everywhere.

### DIFF
--- a/src/follower.ts
+++ b/src/follower.ts
@@ -34,7 +34,7 @@ export default class Follower<T = any> implements PromiseLike<Resource<T>> {
    * This 'then' function behaves like a Promise then() function.
    */
   then<TResult1 = Resource<T>, TResult2 = never>(
-    onfulfilled?: ((value: Resource<any>) => TResult1 | PromiseLike<TResult1>) | null | undefined,
+    onfulfilled?: ((value: Resource<T>) => TResult1 | PromiseLike<TResult1>) | null | undefined,
     onrejected?: ((reason: Error) => TResult2 | PromiseLike<TResult2>) | null | undefined
   ): Promise<TResult1 | TResult2> {
 

--- a/src/follower.ts
+++ b/src/follower.ts
@@ -33,7 +33,7 @@ export default class Follower<T = any> implements PromiseLike<Resource<T>> {
   /**
    * This 'then' function behaves like a Promise then() function.
    */
-  then<TResult1 = Resource<any>, TResult2 = never>(
+  then<TResult1 = Resource<T>, TResult2 = never>(
     onfulfilled?: ((value: Resource<any>) => TResult1 | PromiseLike<TResult1>) | null | undefined,
     onrejected?: ((reason: Error) => TResult2 | PromiseLike<TResult2>) | null | undefined
   ): Promise<TResult1 | TResult2> {
@@ -45,7 +45,7 @@ export default class Follower<T = any> implements PromiseLike<Resource<T>> {
   /**
    * This 'then' function behaves like a Promise then() function.
    */
-  catch<TResult1 = Resource<any>, TResult2 = never>(onrejected?: ((reason: Error) => TResult2 | PromiseLike<TResult2>) | null | undefined): Promise<TResult1 | TResult2> {
+  catch<TResult1 = any, TResult2 = never>(onrejected?: ((reason: Error) => TResult2 | PromiseLike<TResult2>) | null | undefined): Promise<TResult1 | TResult2> {
 
     return this.fetchLinkedResource().then(undefined, onrejected);
 
@@ -58,7 +58,7 @@ export default class Follower<T = any> implements PromiseLike<Resource<T>> {
    *
    * For example: resource.follow('foo').follow('bar');
    */
-  follow(rel: string, variables?: LinkVariables): Follower {
+  follow<TNested = any>(rel: string, variables?: LinkVariables): Follower<TNested> {
 
     return new Follower(this.fetchLinkedResource(), rel, variables);
 
@@ -69,7 +69,7 @@ export default class Follower<T = any> implements PromiseLike<Resource<T>> {
    *
    * For example: resource.follow('foo').followAll('item');
    */
-  async followAll(rel: string): Promise<Resource[]> {
+  async followAll<TNested = any>(rel: string): Promise<Array<Resource<TNested>>> {
 
     return (await this.fetchLinkedResource()).followAll(rel);
 
@@ -79,7 +79,7 @@ export default class Follower<T = any> implements PromiseLike<Resource<T>> {
    * This function does the actual fetching, to obtained the url
    * of the linked resource. It returns the Resource object.
    */
-  private async fetchLinkedResource(): Promise<Resource> {
+  private async fetchLinkedResource(): Promise<Resource<T>> {
 
     const resource = await this.resource;
     const link = await resource.link(this.rel);

--- a/src/follower.ts
+++ b/src/follower.ts
@@ -16,7 +16,7 @@ import { LinkVariables } from './types';
  * * `followAll()`, allowing a user to call `followAll()` at the end of a
  *   chain.
  */
-export default class Follower implements PromiseLike<Resource> {
+export default class Follower<T = any> implements PromiseLike<Resource<T>> {
 
   private resource: Resource | Promise<Resource>;
   private rel: string;

--- a/src/ketting.ts
+++ b/src/ketting.ts
@@ -84,7 +84,7 @@ export default class Ketting {
   /**
    * This function is a shortcut for getResource().follow(x);
    */
-  follow(rel: string, variables?: LinkVariables): Follower {
+  follow<TResource = any>(rel: string, variables?: LinkVariables): Follower<TResource> {
 
     return this.getResource().follow(rel, variables);
 
@@ -99,7 +99,7 @@ export default class Ketting {
    * If a relative uri is passed, it will be resolved based on the bookmark
    * uri.
    */
-  go(uri?: string): Resource {
+  go<TResource = any>(uri?: string): Resource<TResource> {
 
     if (typeof uri === 'undefined') {
       uri = '';

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -21,7 +21,7 @@ import { resolve } from './utils/url';
  * @param {string} uri
  * @constructor
  */
-export default class Resource<T = any> {
+export default class Resource<TResource = any, TPatch = Partial<TResource>> {
 
   /**
    * Reference to the main Client
@@ -31,7 +31,7 @@ export default class Resource<T = any> {
   /**
    * The current representation, or body of the resource.
    */
-  repr: Representation<T> | null;
+  repr: Representation<TResource> | null;
 
   /**
    * The uri of the resource
@@ -75,7 +75,7 @@ export default class Resource<T = any> {
    * Fetches the resource representation.
    * Returns a promise that resolves to a parsed json object.
    */
-  async get(): Promise<T> {
+  async get(): Promise<TResource> {
 
     const r = await this.representation();
     return r.getBody();
@@ -85,7 +85,7 @@ export default class Resource<T = any> {
   /**
    * Updates the resource representation with a new JSON object.
    */
-  async put(body: T): Promise<void> {
+  async put(body: TResource): Promise<void> {
 
     const contentType = this.contentType || this.client.contentTypes[0].mime;
     const params = {
@@ -122,7 +122,7 @@ export default class Resource<T = any> {
    * If no Location header was given, it will resolve still, but with an empty
    * value.
    */
-  async post(body: object): Promise<Resource|null> {
+  async post<TPostResource = any>(body: TResource): Promise<Resource<TPostResource>|null> {
 
     const contentType = this.contentType || this.client.contentTypes[0].mime;
     const response = await this.fetchAndThrow(
@@ -147,7 +147,7 @@ export default class Resource<T = any> {
    *
    * This function defaults to a application/json content-type header.
    */
-  async patch(body: object): Promise<void> {
+  async patch(body: TPatch): Promise<void> {
 
     await this.fetchAndThrow(
       {
@@ -169,7 +169,7 @@ export default class Resource<T = any> {
    *
    * @return {object}
    */
-  async refresh(): Promise<T> {
+  async refresh(): Promise<TResource> {
 
     let response: Response;
     let body: string;
@@ -245,7 +245,7 @@ export default class Resource<T = any> {
       contentType,
       body!,
       headerLinks
-    ) as any as Representation<T>;
+    ) as any as Representation<TResource>;
 
     if (!this.contentType) {
       this.contentType = contentType;
@@ -313,7 +313,7 @@ export default class Resource<T = any> {
    * This function can also follow templated uris. You can specify uri
    * variables in the optional variables argument.
    */
-  follow(rel: string, variables?: LinkVariables): Follower {
+  follow<TFollowedResource = any>(rel: string, variables?: LinkVariables): Follower<TFollowedResource> {
 
     return new Follower(this, rel, variables);
 
@@ -325,7 +325,7 @@ export default class Resource<T = any> {
    *
    * If no resources were found, the array will be empty.
    */
-  async followAll(rel: string): Promise<Resource[]> {
+  async followAll<TFollowedResource = any>(rel: string): Promise<Array<Resource<TFollowedResource>>> {
 
     this.preferPushRels.add(rel);
     const links = await this.links(rel);
@@ -362,7 +362,7 @@ export default class Resource<T = any> {
    * Usually you will want to use the `get()` method instead, unless you need
    * the full object.
    */
-  async representation(): Promise<Representation<T>> {
+  async representation(): Promise<Representation<TResource>> {
 
     if (!this.repr) {
       await this.refresh();

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -348,7 +348,7 @@ export default class Resource<TResource = any, TPatch = Partial<TResource>> {
    *
    * This function doesn't do any HTTP requests.
    */
-  go(uri: string): Resource {
+  go<TGoResource = any>(uri: string): Resource<TGoResource> {
 
     uri = resolve(this.uri, uri);
     return this.client.go(uri);

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -122,7 +122,7 @@ export default class Resource<TResource = any, TPatch = Partial<TResource>> {
    * If no Location header was given, it will resolve still, but with an empty
    * value.
    */
-  async post<TPostResource = any>(body: TResource): Promise<Resource<TPostResource>|null> {
+  async post<TPostResource = any>(body: TPostResource): Promise<Resource<TPostResource>|null> {
 
     const contentType = this.contentType || this.client.contentTypes[0].mime;
     const response = await this.fetchAndThrow(


### PR DESCRIPTION
* patch() can now be typed.
* If no type is supplied for patch bodies, Partial<X> is assumed for
  patch, meaning that we assume that patch bodies will just have a
  subset of properties from the PUT request.
* Types can now be provided when linking.
* If using the post() function with type T as the argument, and the
  HTTP response to POST includes a location header, the function now
  assumes that the resource in this header is of type T, and a
  Resource<T> is returned.