### PR TITLE
Support the 'invalidates' link.

### DIFF
--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,0 +1,5 @@
+const safeMethods = ['GET', 'HEAD', 'OPTIONS', 'PRI', 'PROPFIND', 'REPORT', 'SEARCH', 'TRACE'];
+
+export function isSafeMethod(method: string): boolean {
+  return safeMethods.includes(method);
+}

--- a/test/unit/ketting.ts
+++ b/test/unit/ketting.ts
@@ -3,40 +3,132 @@ import { expect } from 'chai';
 import Ketting from '../../src/ketting';
 import Hal from '../../src/representor/hal';
 import Html from '../../src/representor/html';
+import Siren from '../../src/representor/siren';
 
 describe('Ketting', () => {
 
-  it('should return a HTML representor when requested', () => {
+  describe('createRepresentation', () => {
 
-    const ketting = new Ketting('https://example.org/');
-    const representor = ketting.createRepresentation('/foo', 'text/html', null, new Map());
-    expect(representor).to.be.instanceof(Html);
+    it('should return a HTML representor when requested', () => {
 
-  });
+      const ketting = new Ketting('https://example.org/');
+      const representor = ketting.createRepresentation('/foo', 'text/html', null, new Map());
+      expect(representor).to.be.instanceof(Html);
 
-  it('should return a Hal representor when requested', () => {
-
-    const ketting = new Ketting('https://example.org');
-    const representor = ketting.createRepresentation('/foo', 'application/hal+json', null, new Map());
-    expect(representor).to.be.instanceof(Hal);
-
-  });
-
-  it('should throw an error when an unknown representor was requested ', () => {
-
-    const ketting = new Ketting('https://example.org');
-    expect( () => ketting.createRepresentation('/foo', 'text/plain', '', new Map())).to.throw(Error);
-
-  });
-
-  it('should throw an error an a representor was incorrecly configured ', () => {
-
-    const ketting = new Ketting('https://example.org');
-    ketting.contentTypes.push({
-      mime: 'text/plain',
-      representor: 'bla-bla'
     });
-    expect( () => ketting.createRepresentation('/foo', 'text/plain', '', new Map()) ).to.throw(Error);
+
+    it('should return a Hal representor when requested', () => {
+
+      const ketting = new Ketting('https://example.org');
+      const representor = ketting.createRepresentation('/foo', 'application/hal+json', null, new Map());
+      expect(representor).to.be.instanceof(Hal);
+
+    });
+
+    it('should return a Siren representor when requested', () => {
+
+      const ketting = new Ketting('https://example.org');
+      const representor = ketting.createRepresentation('/foo', 'application/vnd.siren+json', null, new Map());
+      expect(representor).to.be.instanceof(Siren);
+
+    });
+
+    it('should throw an error when an unknown representor was requested ', () => {
+
+      const ketting = new Ketting('https://example.org');
+      expect( () => ketting.createRepresentation('/foo', 'text/plain', '', new Map())).to.throw(Error);
+
+    });
+
+    it('should throw an error an a representor was incorrecly configured ', () => {
+
+      const ketting = new Ketting('https://example.org');
+      ketting.contentTypes.push({
+        mime: 'text/plain',
+        representor: 'bla-bla'
+      });
+      expect( () => ketting.createRepresentation('/foo', 'text/plain', '', new Map()) ).to.throw(Error);
+
+    });
+
+
+  });
+
+  describe('Resource caching', () => {
+
+    it('should invalidate a resource\'s cache if an unsafe method was used', () => {
+
+      let cleared = false;
+
+      const ketting = new Ketting('https://example.org');
+      // @ts-ignore
+      ketting.resourceCache['https://example.org/foo'] = {
+        clearCache: () => {
+          cleared = true;
+        }
+      };
+
+      const request = new Request('https://example.org/foo', {
+        method: 'POST'
+      });
+
+      ketting.beforeRequest(request);
+
+      expect(cleared).to.equal(true);
+
+    });
+
+    it('should not invalidate a resource\'s cache if a safe method was used', () => {
+
+      let cleared = false;
+
+      const ketting = new Ketting('https://example.org');
+      // @ts-ignore
+      ketting.resourceCache['https://example.org/foo'] = {
+        clearCache: () => {
+          cleared = true;
+        }
+      };
+
+      const request = new Request('https://example.org/foo', {
+        method: 'SEARCH'
+      });
+
+      ketting.beforeRequest(request);
+
+      expect(cleared).to.equal(false);
+
+    });
+
+    it('should invalidate resources if they were mentioned in a Link header with rel="invalidates"', () => {
+
+      let cleared = false;
+
+      const ketting = new Ketting('https://example.org');
+      // @ts-ignore
+      ketting.resourceCache['https://example.org/bar'] = {
+        clearCache: () => {
+          cleared = true;
+        }
+      };
+
+      const request = new Request('https://example.org/foo', {
+        method: 'DELETE'
+      });
+      const headers = new Headers();
+      headers.append('Link', '</bar>; rel="invalidates"');
+      headers.append('Link', '</zim>; rel="invalidates"');
+      const response = new Response('', {
+        status: 200,
+        headers
+      });
+
+      ketting.afterRequest(request, response);
+
+      expect(cleared).to.equal(true);
+
+
+    });
 
   });
 


### PR DESCRIPTION
When a HTTP method returns a Link header that contains a
rel="invalidates", then it means that the HTTP request that was recently
performed has caused other resources to change.

For example, given a resource /article/ that has a list of articles, and
a resource /article/123, running a DELETE request on /article/123 will
also cause a change to the articles list.

If the response to DELETE included the following header:

    Link: </article>; rel="invalidates"

Then this can signal a client that the cache for the /article
collection is no longer valid.

The 'invalidates' link relationship is specified in this draft:

https://tools.ietf.org/html/draft-nottingham-linked-cache-inv