### PR TITLE
Capitalizing header name so it actually catches

### DIFF
--- a/src/resource.ts
+++ b/src/resource.ts
@@ -135,8 +135,8 @@ export default class Resource<TResource = any, TPatch = Partial<TResource>> {
       }
     );
 
-    if (response.headers.has('location')) {
-      return this.go(<string> response.headers.get('location'));
+    if (response.headers.has('Location')) {
+      return this.go(<string> response.headers.get('Location'));
     }
     return null;
 


### PR DESCRIPTION
Right now in the browser if you do a POST using ketting (`Resource.post`) it should return the resource you added as a `Location: /url` which ketting should resolve to a Ketting Resource. This doesnt happen in the browser as the browser headings are capitalized and it currently looks for `location` causing the response from your POST to return null.

Just capitalizing the header name Location should fix the problem. 