### PR TITLE
Refactor representor mapping

### DIFF
--- a/src/ketting.ts
+++ b/src/ketting.ts
@@ -1,13 +1,8 @@
 import * as LinkHeader from 'http-link-header';
 import { FollowerOne } from './follower';
-import { LinkSet } from './link';
-import Representor from './representor/base';
-import HalRepresentor from './representor/hal';
-import HtmlRepresentor from './representor/html';
-import JsonApiRepresentor from './representor/jsonapi';
-import SirenRepresentor from './representor/siren';
+import RepresentorHelper from './representor/helper';
 import Resource from './resource';
-import { ContentType, KettingInit, LinkVariables } from './types';
+import { KettingInit, LinkVariables } from './types';
 import FetchHelper from './utils/fetch-helper';
 import './utils/fetch-polyfill';
 import { isSafeMethod } from './utils/http';
@@ -32,12 +27,7 @@ export default class Ketting {
    */
   resourceCache: { [url: string]: Resource };
 
-  /**
-   * Content-Type settings and mappings.
-   *
-   * See the constructor for an example of the structure.
-   */
-  contentTypes: ContentType[];
+  representorHelper: RepresentorHelper;
 
   /**
    * The helper class that calls fetch() for us
@@ -52,7 +42,7 @@ export default class Ketting {
 
     this.resourceCache = {};
 
-    this.contentTypes = [
+    this.representorHelper = new RepresentorHelper([
       {
         mime: 'application/hal+json',
         representor: 'hal',
@@ -78,7 +68,7 @@ export default class Ketting {
         representor: 'html',
         q: '0.7',
       }
-    ];
+    ]);
 
     this.bookMark = bookMark;
     this.fetchHelper = new FetchHelper(options, this.beforeRequest.bind(this), this.afterRequest.bind(this));
@@ -153,50 +143,6 @@ export default class Ketting {
 
   }
 
-  createRepresentation(uri: string, contentType: string, body: string | null, headerLinks: LinkSet): Representor<any> {
-
-    if (contentType.indexOf(';') !== -1) {
-      contentType = contentType.split(';')[0];
-    }
-    contentType = contentType.trim();
-    const result = this.contentTypes.find(item => {
-      return item.mime === contentType;
-    });
-
-    if (!result) {
-      throw new Error('Could not find a representor for contentType: ' + contentType);
-    }
-
-    switch (result.representor) {
-      case 'html' :
-        return new HtmlRepresentor(uri, contentType, body, headerLinks);
-    case 'hal' :
-        return new HalRepresentor(uri, contentType, body, headerLinks);
-    case 'jsonapi' :
-        return new JsonApiRepresentor(uri, contentType, body, headerLinks);
-    case 'siren' :
-        return new SirenRepresentor(uri, contentType, body, headerLinks);
-    default :
-      throw new Error('Unknown representor: ' + result.representor);
-
-    }
-
-  }
-
-  /**
-   * Generates an accept header string, based on registered Resource Types.
-   */
-  getAcceptHeader(): string {
-
-    return this.contentTypes
-      .map( contentType => {
-        let item = contentType.mime;
-        if (contentType.q) { item += ';q=' + contentType.q; }
-        return item;
-      } )
-      .join(', ');
-
-  }
 
   beforeRequest(request: Request): void {
 

--- a/src/ketting.ts
+++ b/src/ketting.ts
@@ -34,7 +34,7 @@ export default class Ketting {
    */
   private fetchHelper: FetchHelper;
 
-  constructor(bookMark: string, options?: Partial<KettingInit>) {
+  constructor(bookMark: string, options?: KettingInit) {
 
     if (typeof options === 'undefined') {
       options = {};
@@ -42,35 +42,11 @@ export default class Ketting {
 
     this.resourceCache = {};
 
-    this.representorHelper = new RepresentorHelper([
-      {
-        mime: 'application/hal+json',
-        representor: 'hal',
-        q: '1.0',
-      },
-      {
-        mime: 'application/vnd.api+json',
-        representor: 'jsonapi',
-        q: '0.9',
-      },
-      {
-        mime: 'application/vnd.siren+json',
-        representor: 'siren',
-        q: '0.9',
-      },
-      {
-        mime: 'application/json',
-        representor: 'hal',
-        q: '0.8',
-      },
-      {
-        mime: 'text/html',
-        representor: 'html',
-        q: '0.7',
-      }
-    ]);
-
     this.bookMark = bookMark;
+
+    this.representorHelper = new RepresentorHelper(
+      options.contentTypes || [],
+    );
     this.fetchHelper = new FetchHelper(options, this.beforeRequest.bind(this), this.afterRequest.bind(this));
 
   }

--- a/src/representor/helper.ts
+++ b/src/representor/helper.ts
@@ -13,7 +13,35 @@ export default class RepresentorHelper {
 
   constructor(contentTypes: ContentType[]) {
 
-    this.contentTypes = contentTypes;
+    const defaultTypes: ContentType[] = [
+      {
+        mime: 'application/hal+json',
+        representor: 'hal',
+        q: '1.0',
+      },
+      {
+        mime: 'application/vnd.api+json',
+        representor: 'jsonapi',
+        q: '0.9',
+      },
+      {
+        mime: 'application/vnd.siren+json',
+        representor: 'siren',
+        q: '0.9',
+      },
+      {
+        mime: 'application/json',
+        representor: 'hal',
+        q: '0.8',
+      },
+      {
+        mime: 'text/html',
+        representor: 'html',
+        q: '0.7',
+      }
+
+    ];
+    this.contentTypes = defaultTypes.concat(contentTypes);
 
   }
 

--- a/src/representor/helper.ts
+++ b/src/representor/helper.ts
@@ -1,0 +1,113 @@
+import HalRepresentor from './hal';
+import HtmlRepresentor from './html';
+import JsonApiRepresentor from './jsonapi';
+import SirenRepresentor from './siren';
+import Representor from './base';
+import { LinkSet, Link } from '../link';
+import { ContentType } from '../types';
+import * as LinkHeader from 'http-link-header';
+
+export default class RepresentorHelper {
+
+  private contentTypes: ContentType[];
+
+  constructor(contentTypes: ContentType[]) {
+
+    this.contentTypes = contentTypes;
+
+  }
+
+  /**
+   * Generates an accept header string, based on registered Resource Types.
+   */
+  getAcceptHeader(): string {
+
+    return this.contentTypes
+      .map( contentType => {
+        let item = contentType.mime;
+        if (contentType.q) { item += ';q=' + contentType.q; }
+        return item;
+      } )
+      .join(', ');
+
+  }
+
+  getMimeTypes(): string[] {
+
+    return this.contentTypes.map( contentType => contentType.mime );
+
+  }
+
+  create(uri: string, contentType: string, body: string | null, headerLinks: LinkSet): Representor<any> {
+
+    const type = this.getRepresentorType(contentType);
+
+    switch (type) {
+      case 'html' :
+        return new HtmlRepresentor(uri, contentType, body, headerLinks);
+      case 'hal' :
+        return new HalRepresentor(uri, contentType, body, headerLinks);
+      case 'jsonapi' :
+        return new JsonApiRepresentor(uri, contentType, body, headerLinks);
+      case 'siren' :
+        return new SirenRepresentor(uri, contentType, body, headerLinks);
+      default :
+        throw new Error('Unknown representor: ' + type);
+    }
+
+  }
+
+  /**
+   * Returns a representor object from a Fetch Response.
+   */
+  createFromResponse(uri: string, response: Response, body: string): Representor<any> {
+
+    const contentType = response.headers.get('Content-Type')!;
+
+    const httpLinkHeader = response.headers.get('Link');
+    const headerLinks: LinkSet = new Map();
+
+    if (httpLinkHeader) {
+
+      for (const httpLink of LinkHeader.parse(httpLinkHeader).refs) {
+        // Looping through individual links
+        for (const rel of httpLink.rel.split(' ')) {
+          // Looping through space separated rel values.
+          const newLink = new Link({
+            rel: rel,
+            context: uri,
+            href: httpLink.uri
+          });
+          if (headerLinks.has(rel)) {
+            headerLinks.get(rel)!.push(newLink);
+          } else {
+            headerLinks.set(rel, [newLink]);
+          }
+        }
+      }
+    }
+
+    return this.create(uri, contentType, body, headerLinks);  
+
+  }
+  
+  private getRepresentorType(contentType: string) {
+
+    if (contentType.indexOf(';') !== -1) {
+      contentType = contentType.split(';')[0];
+    }
+    contentType = contentType.trim();
+    const result = this.contentTypes.find(item => {
+      return item.mime === contentType;
+    });
+
+    if (!result) {
+      throw new Error('Could not find a representor for contentType: ' + contentType);
+    }
+
+    return result.representor;
+  }
+
+
+
+}

--- a/src/representor/helper.ts
+++ b/src/representor/helper.ts
@@ -1,11 +1,11 @@
+import * as LinkHeader from 'http-link-header';
+import { Link, LinkSet } from '../link';
+import { ContentType } from '../types';
+import Representor from './base';
 import HalRepresentor from './hal';
 import HtmlRepresentor from './html';
 import JsonApiRepresentor from './jsonapi';
 import SirenRepresentor from './siren';
-import Representor from './base';
-import { LinkSet, Link } from '../link';
-import { ContentType } from '../types';
-import * as LinkHeader from 'http-link-header';
 
 export default class RepresentorHelper {
 
@@ -87,10 +87,10 @@ export default class RepresentorHelper {
       }
     }
 
-    return this.create(uri, contentType, body, headerLinks);  
+    return this.create(uri, contentType, body, headerLinks);
 
   }
-  
+
   private getRepresentorType(contentType: string) {
 
     if (contentType.indexOf(';') !== -1) {
@@ -107,7 +107,6 @@ export default class RepresentorHelper {
 
     return result.representor;
   }
-
 
 
 }

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -1,8 +1,7 @@
-import * as LinkHeader from 'http-link-header';
 import { FollowerMany, FollowerOne } from './follower';
 import problemFactory from './http-error';
 import Ketting from './ketting';
-import { Link, LinkSet } from './link';
+import { Link } from './link';
 import Representator from './representor/base';
 import { LinkVariables } from './types';
 import { mergeHeaders } from './utils/fetch-helper';
@@ -83,13 +82,13 @@ export default class Resource<TResource = any, TPatch = Partial<TResource>> {
    */
   async put(body: TResource): Promise<void> {
 
-    const contentType = this.contentType || this.client.contentTypes[0].mime;
+    const contentType = this.contentType || this.client.representorHelper.getMimeTypes()[0];
     const params = {
       method: 'PUT',
       body: JSON.stringify(body),
       headers: {
         'Content-Type': contentType,
-        'Accept' : this.contentType ? this.contentType : this.client.getAcceptHeader()
+        'Accept' : this.contentType ? this.contentType : this.client.representorHelper.getAcceptHeader()
       },
     };
     await this.fetchAndThrow(params);
@@ -120,7 +119,7 @@ export default class Resource<TResource = any, TPatch = Partial<TResource>> {
    */
   async post<TPostResource = any>(body: TPostResource): Promise<Resource<TPostResource>|null> {
 
-    const contentType = this.contentType || this.client.contentTypes[0].mime;
+    const contentType = this.contentType || this.client.representorHelper.getMimeTypes()[0];
     const response = await this.fetchAndThrow(
       {
         method: 'POST',
@@ -173,7 +172,7 @@ export default class Resource<TResource = any, TPatch = Partial<TResource>> {
     if (!this.inFlightRefresh) {
 
       const headers: { [name: string]: string } = {
-        Accept: this.contentType ? this.contentType : this.client.getAcceptHeader()
+        Accept: this.contentType ? this.contentType : this.client.representorHelper.getAcceptHeader()
       };
 
       if (this.preferPushRels.size > 0) {
@@ -205,51 +204,21 @@ export default class Resource<TResource = any, TPatch = Partial<TResource>> {
 
     }
 
-    const contentType = response!.headers.get('Content-Type');
-    if (!contentType) {
-      throw new Error('Server did not respond with a Content-Type header');
-    }
-
-    // Extracting HTTP Link header.
-    const httpLinkHeader = response!.headers.get('Link');
-
-    const headerLinks: LinkSet = new Map();
-
-    if (httpLinkHeader) {
-
-      for (const httpLink of LinkHeader.parse(httpLinkHeader).refs) {
-        // Looping through individual links
-        for (const rel of httpLink.rel.split(' ')) {
-          // Looping through space separated rel values.
-          const newLink = new Link({
-            rel: rel,
-            context: this.uri,
-            href: httpLink.uri
-          });
-          if (headerLinks.has(rel)) {
-            headerLinks.get(rel)!.push(newLink);
-          } else {
-            headerLinks.set(rel, [newLink]);
-          }
-        }
-      }
-    }
-    this.repr = this.client.createRepresentation(
+    this.repr = this.client.representorHelper.createFromResponse(
       this.uri,
-      contentType,
+      response!,
       body!,
-      headerLinks
     ) as any as Representator<TResource>;
 
     if (!this.contentType) {
-      this.contentType = contentType;
+      this.contentType = this.repr.contentType;
     }
 
     for (const [subUri, subBody] of Object.entries(this.repr.getEmbedded())) {
       const subResource = this.go(subUri);
-      subResource.repr = this.client.createRepresentation(
+      subResource.repr = this.client.representorHelper.create(
         subUri,
-        contentType,
+        this.repr.contentType,
         null,
         new Map(),
       );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,41 @@
 import { OAuth2Options } from 'fetch-mw-oauth2';
 
+export type KettingInit = {
+
+  /**
+   * Authentication options.
+   */
+  auth?: AuthOptions
+
+  /**
+   * A list of settings passed to the Fetch API.
+   *
+   * It's effectively a list of defaults that are passed as the 'init' argument.
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+   */
+  fetchInit?: RequestInit,
+
+  /**
+   * Per-domain options.
+   *
+   * This setting allows you to override specific options on a per-domain
+   * basis. It's possible to specify wildcards here.
+   */
+  match?: {
+    [domain: string]: {
+      auth?: AuthOptions
+      fetchInit?: RequestInit,
+    }
+  },
+
+  /**
+   * A list of content type mappings.
+   *
+   * This list will be merged with the default list.
+   */
+  contentTypes?: ContentType[]
+};
+
 export type ContentType = {
   mime: string,
   representor: string,
@@ -23,35 +59,6 @@ export type AuthOptions =
   AuthOptionsBasic |
   AuthOptionsBearer |
   AuthOptionsOAuth2;
-
-export type KettingInit = {
-
-  /**
-   * Authentication options.
-   */
-  auth?: AuthOptions
-
-  /**
-   * A list of settings passed to the Fetch API.
-   *
-   * It's effectively a list of defaults that are passed as the 'init' argument.
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
-   */
-  fetchInit: RequestInit,
-
-  /**
-   * Per-domain options.
-   *
-   * This setting allows you to override specific options on a per-domain
-   * basis. It's possible to specify wildcards here.
-   */
-  match: {
-    [domain: string]: {
-      auth?: AuthOptions
-      fetchInit?: RequestInit,
-    }
-  }
-};
 
 /**
  * A key->value map of variables to place in a templated link

--- a/test/unit/representor/helper.ts
+++ b/test/unit/representor/helper.ts
@@ -1,8 +1,59 @@
 import { expect } from 'chai';
 
-import Ketting from '../../src/ketting';
+import Ketting from '../../../src/ketting';
+import Hal from '../../../src/representor/hal';
+import Html from '../../../src/representor/html';
+import Siren from '../../../src/representor/siren';
+import Helper from '../../../src/representor/helper';
 
-describe('Ketting', () => {
+describe('Representor Helper', () => {
+
+  describe('createRepresentation', () => {
+
+    it('should return a HTML representor when requested', () => {
+
+      const helper = new Helper([]);
+      const representor = helper.create('/foo', 'text/html', null, new Map());
+      expect(representor).to.be.instanceof(Html);
+
+    });
+
+    it('should return a Hal representor when requested', () => {
+
+      const helper = new Helper([]);
+      const representor = helper.create('/foo', 'application/hal+json', null, new Map());
+      expect(representor).to.be.instanceof(Hal);
+
+    });
+
+    it('should return a Siren representor when requested', () => {
+
+      const helper = new Helper([]);
+      const representor = helper.create('/foo', 'application/vnd.siren+json', null, new Map());
+      expect(representor).to.be.instanceof(Siren);
+
+    });
+
+    it('should throw an error when an unknown representor was requested ', () => {
+
+      const helper = new Helper([]);
+      expect( () => helper.create('/foo', 'text/plain', '', new Map())).to.throw(Error);
+
+    });
+
+    it('should throw an error an a representor was incorrecly configured ', () => {
+
+      const helper = new Helper([
+        {
+          mime: 'text/plain',
+          representor: 'bla-bla'
+        }
+      ]);
+      expect( () => helper.create('/foo', 'text/plain', '', new Map()) ).to.throw(Error);
+
+    });
+
+  });
 
   describe('Resource caching', () => {
 


### PR DESCRIPTION
Centralized a bunch of the 'representor'-related functionality to a
single class. This makes the Resource and Ketting classes a tad easier
to understand.

It's not quite simple enough yet, but it's making headway.

